### PR TITLE
Update documentation with new e2e testing commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,10 @@ Required environment variables:
 Optional for full user management:
 - `SUPABASE_SERVICE_ROLE_KEY` - Service role key for admin user management functions
 
+## Node.js Version Requirements
+
+- **Node.js** >= 22.12.0 (specified in package.json engines)
+
 ## Game Data Structure
 
 ### Heroes
@@ -171,6 +175,8 @@ The project uses a comprehensive testing approach with **Vitest** for unit/integ
 - `npm run e2e:debug` - Run tests in debug mode (step through)
 - `npm run e2e:ui` - Run tests with Playwright UI
 - `npm run e2e:report` - View test results report
+- `npm run e2e:debug-tools` - Run tests tagged with @debug-tools
+- `npm run e2e:no-debug` - Run tests excluding @debug-tools
 
 #### E2E Testing Features
 - **DOM Snapshots**: Automatic HTML and screenshot capture at key test steps

--- a/README.md
+++ b/README.md
@@ -187,11 +187,13 @@ npm run test:ui       # Run with UI interface
 ### End-to-End Testing (Playwright)
 
 ```bash
-npm run e2e           # Run all e2e tests
-npm run e2e:headed    # Run tests with browser UI visible
-npm run e2e:debug     # Run tests in debug mode (step through)
-npm run e2e:ui        # Run tests with Playwright UI
-npm run e2e:report    # View test results report
+npm run e2e              # Run all e2e tests
+npm run e2e:headed       # Run tests with browser UI visible
+npm run e2e:debug        # Run tests in debug mode (step through)
+npm run e2e:ui           # Run tests with Playwright UI
+npm run e2e:report       # View test results report
+npm run e2e:debug-tools  # Run tests tagged with @debug-tools
+npm run e2e:no-debug     # Run tests excluding @debug-tools
 ```
 
 **E2E Testing Features:**


### PR DESCRIPTION
## Summary
- Add new e2e testing commands (`npm run e2e:debug-tools` and `npm run e2e:no-debug`) to both CLAUDE.md and README.md
- Add Node.js version requirement (>= 22.12.0) to CLAUDE.md
- Update testing command documentation to match current package.json scripts

## Test plan
- [x] Documentation changes only, no code changes
- [x] Verified commands exist in package.json
- [x] Updated both CLAUDE.md and README.md consistently

🤖 Generated with [Claude Code](https://claude.ai/code)