### PR TITLE
feat(static): add static mode to run app without Supabase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,13 @@
       "url": "./app/data/hero-schema.json"
     }
   ],
-  "explorer.excludeGitIgnore": true,
+  "files.exclude": {
+    "**/.git": true,
+    "**/.netlify": true,
+    "**/.react-router": true,
+    "**/supabase/.branches": true,
+    "**/supabase/.temp": true
+  },
+  "explorer.excludeGitIgnore": false,
   "postman.settings.dotenv-detection-notification-visibility": false
 }

--- a/app/components/SiteSidebar.tsx
+++ b/app/components/SiteSidebar.tsx
@@ -41,17 +41,25 @@ export function SiteSidebar({
   };
 }) {
   const { isMobile, setOpenMobile } = useSidebar();
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, isStaticMode } = useAuth();
 
-  // Filter navigation groups based on current auth state
-  const navgroups = navigation.filter(
-    (group) =>
-      !("roles" in group) ||
-      (isAuthenticated &&
+  // Filter navigation groups based on current auth state and static mode
+  const navgroups = navigation.filter((group) => {
+    // Exclude auth-required groups when running in static mode
+    if (isStaticMode && group.requiresAuth) return false;
+
+    // Exclude role-restricted groups when not authenticated or lacking the required role
+    if ("roles" in group) {
+      return (
+        isAuthenticated &&
         user?.roles.some((role) =>
-          (group.roles as ReadonlyArray<string>).includes(role)
-        ))
-  );
+          (group.roles as ReadonlyArray<string>).includes(role),
+        )
+      );
+    }
+
+    return true;
+  });
 
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -94,7 +102,7 @@ export function SiteSidebar({
                             <item.icon
                               className={cn(
                                 "inline",
-                                isActive && "fill-green-300"
+                                isActive && "fill-green-300",
                               )}
                             />
                             <span>{item.name}</span>

--- a/app/components/SiteUserMenu.tsx
+++ b/app/components/SiteUserMenu.tsx
@@ -24,7 +24,11 @@ import { useAuth } from "~/contexts/AuthContext";
 
 export function SiteUserMenu() {
   const { isMobile, state } = useSidebar();
-  const { isAuthenticated, user, signOut } = useAuth();
+  const { isAuthenticated, user, signOut, isStaticMode } = useAuth();
+
+  if (isStaticMode) {
+    return null;
+  }
 
   return (
     <div>
@@ -99,10 +103,7 @@ export function SiteUserMenu() {
         </SidebarMenu>
       ) : state === "expanded" ? (
         <LoginModal>
-          <Button
-            variant="outline"
-            className="w-full flex items-center gap-2"
-          >
+          <Button variant="outline" className="w-full flex items-center gap-2">
             <LogInIcon />
             <span>Sign in</span>
           </Button>

--- a/app/components/SiteUserMenu.tsx
+++ b/app/components/SiteUserMenu.tsx
@@ -41,7 +41,7 @@ export function SiteUserMenu() {
                   size="lg"
                   className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                 >
-                  <Avatar className="h-8 w-8 rounded-lg">
+                  <Avatar className="size-8 rounded-lg">
                     <AvatarImage src={`${user.avatar}`} alt={user.name} />
                     <AvatarFallback className="rounded-lg">
                       {user.fallback}
@@ -62,7 +62,7 @@ export function SiteUserMenu() {
               >
                 <DropdownMenuLabel className="p-0 font-normal">
                   <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <Avatar className="h-8 w-8 rounded-lg">
+                    <Avatar className="size-8 rounded-lg">
                       <AvatarImage src={`${user.avatar}`} alt={user.name} />
                       <AvatarFallback className="rounded-lg">
                         {user.fallback}

--- a/app/components/auth/UnauthorizedAccess.tsx
+++ b/app/components/auth/UnauthorizedAccess.tsx
@@ -1,3 +1,6 @@
+// ABOUTME: Displays an appropriate access-denied message based on auth state.
+// ABOUTME: Shows a read-only mode card in static mode, or auth/permission errors otherwise.
+
 import { Link } from "react-router";
 
 import { Button } from "~/components/ui/button";
@@ -8,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
+import { useAuth } from "~/contexts/AuthContext";
 import { useRoles } from "~/hooks/useRoles";
 
 interface UnauthorizedAccessProps {
@@ -19,7 +23,26 @@ export function UnauthorizedAccess({
   requiredRole = "editor",
   action = "edit this content",
 }: UnauthorizedAccessProps) {
+  const { isStaticMode } = useAuth();
   const { isAuthenticated, user } = useRoles();
+
+  if (isStaticMode) {
+    return (
+      <Card className="mx-auto max-w-md">
+        <CardHeader>
+          <CardTitle>Read-Only Mode</CardTitle>
+          <CardDescription>
+            This feature is not available in read-only mode.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild variant="outline">
+            <Link to="/">Go to Homepage</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
 
   if (!isAuthenticated) {
     return (

--- a/app/components/auth/__tests__/UnauthorizedAccess.test.tsx
+++ b/app/components/auth/__tests__/UnauthorizedAccess.test.tsx
@@ -4,13 +4,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { UnauthorizedAccess } from "../UnauthorizedAccess";
 
+import { useAuth } from "~/contexts/AuthContext";
 import { useRoles } from "~/hooks/useRoles";
+
+// Mock the AuthContext (required because UnauthorizedAccess uses useAuth for isStaticMode)
+vi.mock("~/contexts/AuthContext", () => ({
+  useAuth: vi.fn(() => ({
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    isStaticMode: false,
+    signOut: vi.fn(),
+    updateProfile: vi.fn(),
+  })),
+}));
 
 // Mock the useRoles hook
 vi.mock("~/hooks/useRoles", () => ({
   useRoles: vi.fn(),
 }));
 
+const mockUseAuth = vi.mocked(useAuth);
 const mockUseRoles = vi.mocked(useRoles);
 
 // Helper component to wrap with router
@@ -40,12 +54,12 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Authentication Required")).toBeInTheDocument();
       expect(
-        result.getByText("You must be logged in to edit this content.")
+        result.getByText("You must be logged in to edit this content."),
       ).toBeInTheDocument();
       expect(result.getByRole("link", { name: "Sign In" })).toBeInTheDocument();
     });
@@ -54,12 +68,12 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess action="access this feature" />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Authentication Required")).toBeInTheDocument();
       expect(
-        result.getByText("You must be logged in to access this feature.")
+        result.getByText("You must be logged in to access this feature."),
       ).toBeInTheDocument();
     });
 
@@ -67,7 +81,7 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       const signInLink = result.getByRole("link", { name: "Sign In" });
@@ -99,12 +113,12 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Insufficient Permissions")).toBeInTheDocument();
       expect(
-        result.getByText("You need editor role to edit this content.")
+        result.getByText("You need editor role to edit this content."),
       ).toBeInTheDocument();
     });
 
@@ -112,12 +126,12 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess requiredRole="admin" action="manage users" />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Insufficient Permissions")).toBeInTheDocument();
       expect(
-        result.getByText("You need admin role to manage users.")
+        result.getByText("You need admin role to manage users."),
       ).toBeInTheDocument();
     });
 
@@ -125,7 +139,7 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Current user: Test User")).toBeInTheDocument();
@@ -154,7 +168,7 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Your roles: user, viewer")).toBeInTheDocument();
@@ -164,7 +178,7 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       const heroesLink = result.getByRole("link", { name: "Back to Heroes" });
@@ -199,7 +213,7 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Your roles:")).toBeInTheDocument();
@@ -226,7 +240,7 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess requiredRole="moderator" />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Required role: moderator")).toBeInTheDocument();
@@ -248,11 +262,11 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(
-        result.getByRole("heading", { name: "Authentication Required" })
+        result.getByRole("heading", { name: "Authentication Required" }),
       ).toBeInTheDocument();
     });
 
@@ -277,14 +291,14 @@ describe("UnauthorizedAccess", () => {
       const result = render(
         <Wrapper>
           <UnauthorizedAccess />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(
-        result.getByRole("link", { name: "Back to Heroes" })
+        result.getByRole("link", { name: "Back to Heroes" }),
       ).toBeInTheDocument();
       expect(
-        result.getByRole("link", { name: "Back to Equipment" })
+        result.getByRole("link", { name: "Back to Equipment" }),
       ).toBeInTheDocument();
     });
   });

--- a/app/components/auth/__tests__/UnauthorizedAccess.test.tsx
+++ b/app/components/auth/__tests__/UnauthorizedAccess.test.tsx
@@ -35,6 +35,85 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 describe("UnauthorizedAccess", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset useAuth to non-static mode default so tests that don't override it start clean
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      isStaticMode: false,
+      signOut: vi.fn(),
+      updateProfile: vi.fn(),
+    });
+  });
+
+  describe("when app is in static mode", () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        isStaticMode: true,
+        signOut: vi.fn(),
+        updateProfile: vi.fn(),
+      });
+      mockUseRoles.mockReturnValue({
+        hasRole: vi.fn(() => false),
+        canEdit: vi.fn(() => false),
+        isAdmin: vi.fn(() => false),
+        isUser: vi.fn(() => false),
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+      });
+    });
+
+    it("shows Read-Only Mode heading", () => {
+      const result = render(
+        <Wrapper>
+          <UnauthorizedAccess />
+        </Wrapper>,
+      );
+
+      expect(
+        result.getByRole("heading", { name: "Read-Only Mode" }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows a link to the homepage", () => {
+      const result = render(
+        <Wrapper>
+          <UnauthorizedAccess />
+        </Wrapper>,
+      );
+
+      const homeLink = result.getByRole("link", { name: "Go to Homepage" });
+      expect(homeLink).toBeInTheDocument();
+      expect(homeLink).toHaveAttribute("href", "/");
+    });
+
+    it("does not show Authentication Required heading", () => {
+      const result = render(
+        <Wrapper>
+          <UnauthorizedAccess />
+        </Wrapper>,
+      );
+
+      expect(
+        result.queryByText("Authentication Required"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show Insufficient Permissions heading", () => {
+      const result = render(
+        <Wrapper>
+          <UnauthorizedAccess />
+        </Wrapper>,
+      );
+
+      expect(
+        result.queryByText("Insufficient Permissions"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("when user is not authenticated", () => {

--- a/app/contexts/AuthContext.test.tsx
+++ b/app/contexts/AuthContext.test.tsx
@@ -1,35 +1,178 @@
+// ABOUTME: Tests for AuthContext, covering static mode and normal authenticated state.
+// ABOUTME: Verifies the context provides correct values in each operating mode.
+
+import React from "react";
+
+import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the auth context since we're testing components, not the full auth flow
-vi.mock("~/contexts/AuthContext", () => ({
-  useAuth: vi.fn(() => ({
-    user: {
-      id: "test-user-id",
-      email: "test@example.com",
-      name: "Test User",
-      roles: ["user"],
-      fallback: "TU",
-      avatar: null,
-    },
-    isAuthenticated: true,
-    isLoading: false,
-    signOut: vi.fn(),
-    updateProfile: vi.fn(),
-  })),
-  AuthProvider: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+// Mock static-mode detection so we can control it per-test
+vi.mock("~/lib/static-mode", () => ({
+  isStaticMode: vi.fn(() => false),
 }));
 
-describe("AuthContext Integration", () => {
+// Mock the Supabase client to avoid real network calls
+vi.mock("~/lib/supabase/client", () => ({
+  createClient: vi.fn(() => ({
+    supabase: {
+      auth: {
+        getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+        onAuthStateChange: vi.fn(() => ({
+          data: { subscription: { unsubscribe: vi.fn() } },
+        })),
+        signOut: vi.fn().mockResolvedValue({ error: null }),
+        updateUser: vi.fn().mockResolvedValue({ error: null }),
+      },
+    },
+    headers: new Headers(),
+  })),
+}));
+
+import { isStaticMode } from "~/lib/static-mode";
+import { AuthProvider, useAuth } from "./AuthContext";
+
+const mockIsStaticMode = vi.mocked(isStaticMode);
+
+// Helper component to read auth context values
+function AuthContextReader({
+  onValue,
+}: {
+  onValue: (value: ReturnType<typeof useAuth>) => void;
+}) {
+  const auth = useAuth();
+  onValue(auth);
+  return null;
+}
+
+describe("AuthProvider in static mode", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsStaticMode.mockReturnValue(true);
   });
 
-  it("should be tested with proper Supabase mocking", () => {
-    // For now, this is a placeholder test
-    // Real auth context tests would require proper Supabase client mocking
-    // which is complex with the current architecture
-    expect(true).toBe(true);
+  it("provides null user", () => {
+    const mockRequest = new Request("http://localhost/");
+    let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+    render(
+      <AuthProvider request={mockRequest}>
+        <AuthContextReader onValue={(v) => (capturedAuth = v)} />
+      </AuthProvider>,
+    );
+
+    expect(capturedAuth).not.toBeNull();
+    expect(capturedAuth!.user).toBeNull();
+  });
+
+  it("provides isAuthenticated as false", () => {
+    const mockRequest = new Request("http://localhost/");
+    let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+    render(
+      <AuthProvider request={mockRequest}>
+        <AuthContextReader onValue={(v) => (capturedAuth = v)} />
+      </AuthProvider>,
+    );
+
+    expect(capturedAuth!.isAuthenticated).toBe(false);
+  });
+
+  it("provides isLoading as false", () => {
+    const mockRequest = new Request("http://localhost/");
+    let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+    render(
+      <AuthProvider request={mockRequest}>
+        <AuthContextReader onValue={(v) => (capturedAuth = v)} />
+      </AuthProvider>,
+    );
+
+    expect(capturedAuth!.isLoading).toBe(false);
+  });
+
+  it("provides isStaticMode as true", () => {
+    const mockRequest = new Request("http://localhost/");
+    let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+    render(
+      <AuthProvider request={mockRequest}>
+        <AuthContextReader onValue={(v) => (capturedAuth = v)} />
+      </AuthProvider>,
+    );
+
+    expect(capturedAuth!.isStaticMode).toBe(true);
+  });
+
+  it("provides no-op signOut that resolves without error", async () => {
+    const mockRequest = new Request("http://localhost/");
+    let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+    render(
+      <AuthProvider request={mockRequest}>
+        <AuthContextReader onValue={(v) => (capturedAuth = v)} />
+      </AuthProvider>,
+    );
+
+    await expect(capturedAuth!.signOut()).resolves.toBeUndefined();
+  });
+});
+
+describe("AuthProvider in live mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsStaticMode.mockReturnValue(false);
+  });
+
+  it("provides isStaticMode as false", () => {
+    const mockRequest = new Request("http://localhost/");
+    let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+    render(
+      <AuthProvider request={mockRequest}>
+        <AuthContextReader onValue={(v) => (capturedAuth = v)} />
+      </AuthProvider>,
+    );
+
+    expect(capturedAuth!.isStaticMode).toBe(false);
+  });
+
+  it("starts in loading state", () => {
+    const mockRequest = new Request("http://localhost/");
+    let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+    render(
+      <AuthProvider request={mockRequest}>
+        <AuthContextReader onValue={(v) => (capturedAuth = v)} />
+      </AuthProvider>,
+    );
+
+    // Initial state is loading (resolves async)
+    expect(capturedAuth!.isLoading).toBe(true);
+  });
+
+  it("provides null user when no session", () => {
+    const mockRequest = new Request("http://localhost/");
+    let capturedAuth: ReturnType<typeof useAuth> | null = null;
+
+    render(
+      <AuthProvider request={mockRequest}>
+        <AuthContextReader onValue={(v) => (capturedAuth = v)} />
+      </AuthProvider>,
+    );
+
+    expect(capturedAuth!.user).toBeNull();
+  });
+});
+
+describe("useAuth outside AuthProvider", () => {
+  it("throws when used outside of an AuthProvider", () => {
+    function ComponentWithoutProvider() {
+      useAuth();
+      return null;
+    }
+
+    expect(() => render(<ComponentWithoutProvider />)).toThrow(
+      "useAuth must be used within an AuthProvider",
+    );
   });
 });

--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -63,10 +63,17 @@ function LiveAuthProvider({
   // Set up Supabase Auth event listeners
   useEffect(() => {
     // Get initial session
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSupabaseUser(session?.user ?? null);
-      setLoading(false);
-    });
+    supabase.auth
+      .getSession()
+      .then(({ data: { session } }) => {
+        setSupabaseUser(session?.user ?? null);
+        setLoading(false);
+      })
+      .catch((error) => {
+        log.error("Failed to get auth session:", error);
+        setSupabaseUser(null);
+        setLoading(false);
+      });
 
     // Listen for auth changes
     const {

--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -1,3 +1,6 @@
+// ABOUTME: React context for authentication state, shared across the component tree.
+// ABOUTME: Supports static mode (no Supabase) by returning a null-user, unauthenticated context.
+
 import {
   createContext,
   useCallback,
@@ -11,6 +14,8 @@ import { type AuthError, type User } from "@supabase/supabase-js";
 import log from "loglevel";
 
 import { createClient } from "~/lib/supabase/client";
+import { isStaticMode } from "~/lib/static-mode";
+
 interface AuthContextType {
   user: {
     id: string;
@@ -22,13 +27,29 @@ interface AuthContextType {
   } | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  isStaticMode: boolean;
   signOut: () => Promise<void>;
   updateProfile: (data: { full_name: string }) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
-export function AuthProvider({
+// Provides a no-op auth context when the application runs without Supabase
+function StaticAuthProvider({ children }: { children: React.ReactNode }) {
+  const value: AuthContextType = {
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    isStaticMode: true,
+    signOut: async () => {},
+    updateProfile: async () => {},
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+// Provides live Supabase-backed auth context for normal (non-static) operation
+function LiveAuthProvider({
   children,
   request,
 }: {
@@ -68,7 +89,7 @@ export function AuthProvider({
 
     // Get name from metadata or use fallback
     const fullName = String(
-      userMetadata.full_name || userMetadata.name || "Anonymous Shroom"
+      userMetadata.full_name || userMetadata.name || "Anonymous Shroom",
     );
 
     // Create fallback initials from name
@@ -111,7 +132,7 @@ export function AuthProvider({
         throw error;
       }
     },
-    [supabase.auth]
+    [supabase.auth],
   );
 
   const value = useMemo(
@@ -119,13 +140,28 @@ export function AuthProvider({
       user: transformedUser,
       isAuthenticated: Boolean(supabaseUser),
       isLoading: loading,
+      isStaticMode: false,
       signOut,
       updateProfile,
     }),
-    [transformedUser, supabaseUser, loading, signOut, updateProfile]
+    [transformedUser, supabaseUser, loading, signOut, updateProfile],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function AuthProvider({
+  children,
+  request,
+}: {
+  children: React.ReactNode;
+  request: Request;
+}) {
+  if (isStaticMode()) {
+    return <StaticAuthProvider>{children}</StaticAuthProvider>;
+  }
+
+  return <LiveAuthProvider request={request}>{children}</LiveAuthProvider>;
 }
 
 export function useAuth() {

--- a/app/data/navigation.ts
+++ b/app/data/navigation.ts
@@ -18,6 +18,7 @@ interface NavigationGroup {
   icon?: React.ComponentType<{ className?: string }>;
   items: NavigationItem[];
   roles?: string[];
+  requiresAuth?: boolean;
 }
 
 interface NavigationItem {
@@ -75,6 +76,7 @@ export const navigation: NavigationGroup[] = [
   },
   {
     name: "Player Tools",
+    requiresAuth: true,
     items: [
       {
         name: "Hero Roster",

--- a/app/hooks/__tests__/useRoles.test.tsx
+++ b/app/hooks/__tests__/useRoles.test.tsx
@@ -23,6 +23,7 @@ describe("useRoles", () => {
         user: null,
         isAuthenticated: false,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -68,6 +69,7 @@ describe("useRoles", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -120,6 +122,7 @@ describe("useRoles", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -171,6 +174,7 @@ describe("useRoles", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -216,6 +220,7 @@ describe("useRoles", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -240,6 +245,7 @@ describe("useRoles", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -262,6 +268,7 @@ describe("useRoles", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });

--- a/app/layouts/__tests__/ProtectedEditorLayout.test.tsx
+++ b/app/layouts/__tests__/ProtectedEditorLayout.test.tsx
@@ -47,6 +47,7 @@ describe("ProtectedEditorLayout", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -56,7 +57,7 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Protected Content")).toBeInTheDocument();
@@ -66,11 +67,15 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
-      expect(result.queryByText("Insufficient Permissions")).not.toBeInTheDocument();
-      expect(result.queryByText("Authentication Required")).not.toBeInTheDocument();
+      expect(
+        result.queryByText("Insufficient Permissions"),
+      ).not.toBeInTheDocument();
+      expect(
+        result.queryByText("Authentication Required"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -87,6 +92,7 @@ describe("ProtectedEditorLayout", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -96,7 +102,7 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Protected Content")).toBeInTheDocument();
@@ -116,6 +122,7 @@ describe("ProtectedEditorLayout", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -125,7 +132,7 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Protected Content")).toBeInTheDocument();
@@ -145,6 +152,7 @@ describe("ProtectedEditorLayout", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -154,18 +162,20 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Insufficient Permissions")).toBeInTheDocument();
-      expect(result.getByText("You need admin or editor role to access this page.")).toBeInTheDocument();
+      expect(
+        result.getByText("You need admin or editor role to access this page."),
+      ).toBeInTheDocument();
     });
 
     it("does not render the outlet content", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.queryByText("Protected Content")).not.toBeInTheDocument();
@@ -175,12 +185,14 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Current user: Test User")).toBeInTheDocument();
       expect(result.getByText("Your roles: user")).toBeInTheDocument();
-      expect(result.getByText("Required role: admin or editor")).toBeInTheDocument();
+      expect(
+        result.getByText("Required role: admin or editor"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -190,6 +202,7 @@ describe("ProtectedEditorLayout", () => {
         user: null,
         isAuthenticated: false,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -199,18 +212,20 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Authentication Required")).toBeInTheDocument();
-      expect(result.getByText("You must be logged in to access this page.")).toBeInTheDocument();
+      expect(
+        result.getByText("You must be logged in to access this page."),
+      ).toBeInTheDocument();
     });
 
     it("does not render the outlet content", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.queryByText("Protected Content")).not.toBeInTheDocument();
@@ -220,7 +235,7 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByRole("link", { name: "Sign In" })).toBeInTheDocument();
@@ -240,6 +255,7 @@ describe("ProtectedEditorLayout", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -247,7 +263,7 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Insufficient Permissions")).toBeInTheDocument();
@@ -266,6 +282,7 @@ describe("ProtectedEditorLayout", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -273,7 +290,7 @@ describe("ProtectedEditorLayout", () => {
       const result = render(
         <Wrapper>
           <ProtectedEditorLayout />
-        </Wrapper>
+        </Wrapper>,
       );
 
       expect(result.getByText("Insufficient Permissions")).toBeInTheDocument();

--- a/app/lib/__tests__/static-mode.test.ts
+++ b/app/lib/__tests__/static-mode.test.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Tests for static mode detection utility.
+// ABOUTME: Verifies correct behavior when Supabase env vars are present or absent.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("isStaticMode", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it("returns true when SUPABASE_DATABASE_URL is not set", async () => {
+    delete process.env.SUPABASE_DATABASE_URL;
+    const { isStaticMode } = await import("../static-mode");
+    expect(isStaticMode()).toBe(true);
+  });
+
+  it("returns false when SUPABASE_DATABASE_URL is set to a valid URL", async () => {
+    process.env.SUPABASE_DATABASE_URL = "https://example.supabase.co";
+    const { isStaticMode } = await import("../static-mode");
+    expect(isStaticMode()).toBe(false);
+  });
+
+  it("returns true when SUPABASE_DATABASE_URL is an empty string", async () => {
+    process.env.SUPABASE_DATABASE_URL = "";
+    const { isStaticMode } = await import("../static-mode");
+    expect(isStaticMode()).toBe(true);
+  });
+
+  it("returns false when SUPABASE_DATABASE_URL is set to any non-empty value", async () => {
+    process.env.SUPABASE_DATABASE_URL = "postgresql://localhost:5432/db";
+    const { isStaticMode } = await import("../static-mode");
+    expect(isStaticMode()).toBe(false);
+  });
+});

--- a/app/lib/__tests__/static-mode.test.ts
+++ b/app/lib/__tests__/static-mode.test.ts
@@ -11,26 +11,51 @@ describe("isStaticMode", () => {
     vi.resetModules();
   });
 
-  it("returns true when SUPABASE_DATABASE_URL is not set", async () => {
-    delete process.env.SUPABASE_DATABASE_URL;
-    const { isStaticMode } = await import("../static-mode");
-    expect(isStaticMode()).toBe(true);
-  });
-
-  it("returns false when SUPABASE_DATABASE_URL is set to a valid URL", async () => {
+  it("returns false when both SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY are set", async () => {
     process.env.SUPABASE_DATABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_ANON_KEY = "anon-key-value";
     const { isStaticMode } = await import("../static-mode");
     expect(isStaticMode()).toBe(false);
   });
 
-  it("returns true when SUPABASE_DATABASE_URL is an empty string", async () => {
-    process.env.SUPABASE_DATABASE_URL = "";
+  it("returns true when only SUPABASE_DATABASE_URL is set (SUPABASE_ANON_KEY missing)", async () => {
+    process.env.SUPABASE_DATABASE_URL = "https://example.supabase.co";
+    delete process.env.SUPABASE_ANON_KEY;
     const { isStaticMode } = await import("../static-mode");
     expect(isStaticMode()).toBe(true);
   });
 
-  it("returns false when SUPABASE_DATABASE_URL is set to any non-empty value", async () => {
+  it("returns true when only SUPABASE_ANON_KEY is set (SUPABASE_DATABASE_URL missing)", async () => {
+    delete process.env.SUPABASE_DATABASE_URL;
+    process.env.SUPABASE_ANON_KEY = "anon-key-value";
+    const { isStaticMode } = await import("../static-mode");
+    expect(isStaticMode()).toBe(true);
+  });
+
+  it("returns true when neither SUPABASE_DATABASE_URL nor SUPABASE_ANON_KEY is set", async () => {
+    delete process.env.SUPABASE_DATABASE_URL;
+    delete process.env.SUPABASE_ANON_KEY;
+    const { isStaticMode } = await import("../static-mode");
+    expect(isStaticMode()).toBe(true);
+  });
+
+  it("returns true when SUPABASE_DATABASE_URL is an empty string", async () => {
+    process.env.SUPABASE_DATABASE_URL = "";
+    process.env.SUPABASE_ANON_KEY = "anon-key-value";
+    const { isStaticMode } = await import("../static-mode");
+    expect(isStaticMode()).toBe(true);
+  });
+
+  it("returns true when SUPABASE_ANON_KEY is an empty string", async () => {
+    process.env.SUPABASE_DATABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_ANON_KEY = "";
+    const { isStaticMode } = await import("../static-mode");
+    expect(isStaticMode()).toBe(true);
+  });
+
+  it("returns false when both env vars are set to non-empty values", async () => {
     process.env.SUPABASE_DATABASE_URL = "postgresql://localhost:5432/db";
+    process.env.SUPABASE_ANON_KEY = "some-anon-key";
     const { isStaticMode } = await import("../static-mode");
     expect(isStaticMode()).toBe(false);
   });

--- a/app/lib/auth/utils.test.ts
+++ b/app/lib/auth/utils.test.ts
@@ -1,0 +1,137 @@
+// ABOUTME: Tests for authentication utility functions, including static mode behavior.
+// ABOUTME: Verifies early returns and errors are thrown correctly in static mode.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the static-mode module so we can control it per-test
+vi.mock("~/lib/static-mode", () => ({
+  isStaticMode: vi.fn(() => false),
+}));
+
+// Mock the supabase client
+vi.mock("~/lib/supabase/client", () => ({
+  createClient: vi.fn(() => ({
+    supabase: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: null,
+        }),
+      },
+    },
+    headers: new Headers(),
+  })),
+}));
+
+// Mock the AuthContext (useAuth is only used in client-side hooks, not in server utilities)
+vi.mock("~/contexts/AuthContext", () => ({
+  useAuth: vi.fn(() => ({
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    isStaticMode: false,
+    signOut: vi.fn(),
+    updateProfile: vi.fn(),
+  })),
+}));
+
+import { isStaticMode } from "~/lib/static-mode";
+import {
+  getAuthenticatedUser,
+  requireAuthenticatedUser,
+  isAuthenticated,
+} from "./utils";
+
+const mockIsStaticMode = vi.mocked(isStaticMode);
+
+describe("getAuthenticatedUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsStaticMode.mockReturnValue(false);
+  });
+
+  it("returns null user and null error in static mode", async () => {
+    mockIsStaticMode.mockReturnValue(true);
+    const mockRequest = new Request("http://localhost/");
+
+    const result = await getAuthenticatedUser(mockRequest);
+
+    expect(result).toEqual({ user: null, error: null });
+  });
+
+  it("calls Supabase when not in static mode", async () => {
+    mockIsStaticMode.mockReturnValue(false);
+    const mockRequest = new Request("http://localhost/");
+
+    const result = await getAuthenticatedUser(mockRequest);
+
+    // Should return from the mocked Supabase client (null user, no error)
+    expect(result.error).toBeNull();
+    expect(result.user).toBeNull();
+  });
+});
+
+describe("requireAuthenticatedUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsStaticMode.mockReturnValue(false);
+  });
+
+  it("throws 403 Response in static mode", async () => {
+    mockIsStaticMode.mockReturnValue(true);
+    const mockRequest = new Request("http://localhost/");
+
+    let thrown: unknown;
+    try {
+      await requireAuthenticatedUser(mockRequest);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(Response);
+    const response = thrown as Response;
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("Not available in read-only mode");
+  });
+
+  it("throws 401 Response when user is not authenticated (non-static mode)", async () => {
+    mockIsStaticMode.mockReturnValue(false);
+    const mockRequest = new Request("http://localhost/");
+
+    let thrown: unknown;
+    try {
+      await requireAuthenticatedUser(mockRequest);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(Response);
+    const response = thrown as Response;
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("isAuthenticated", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsStaticMode.mockReturnValue(false);
+  });
+
+  it("returns false in static mode", async () => {
+    mockIsStaticMode.mockReturnValue(true);
+    const mockRequest = new Request("http://localhost/");
+
+    const result = await isAuthenticated(mockRequest);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when no user in non-static mode", async () => {
+    mockIsStaticMode.mockReturnValue(false);
+    const mockRequest = new Request("http://localhost/");
+
+    const result = await isAuthenticated(mockRequest);
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/lib/auth/utils.ts
+++ b/app/lib/auth/utils.ts
@@ -4,6 +4,7 @@
 import type { User } from "@supabase/supabase-js";
 
 import { useAuth } from "~/contexts/AuthContext";
+import { isStaticMode } from "~/lib/static-mode";
 
 // Define the auth context user type based on the actual AuthContext
 export interface AuthContextUser {
@@ -33,8 +34,12 @@ export interface ClientAuthResult {
  * Pass the request object to indicate server-side usage
  */
 export async function getAuthenticatedUser(
-  request: Request
+  request: Request,
 ): Promise<ServerAuthResult> {
+  if (isStaticMode()) {
+    return { user: null, error: null };
+  }
+
   try {
     const { createClient } = await import("~/lib/supabase/client");
     const { supabase } = createClient(request);
@@ -68,8 +73,12 @@ export async function getAuthenticatedUser(
  * Use this when authentication is required for the route
  */
 export async function requireAuthenticatedUser(
-  request: Request
+  request: Request,
 ): Promise<User> {
+  if (isStaticMode()) {
+    throw new Response("Not available in read-only mode", { status: 403 });
+  }
+
   const { user, error } = await getAuthenticatedUser(request);
 
   if (error) {
@@ -88,6 +97,10 @@ export async function requireAuthenticatedUser(
  * Returns true if authenticated, false otherwise
  */
 export async function isAuthenticated(request: Request): Promise<boolean> {
+  if (isStaticMode()) {
+    return false;
+  }
+
   const { user } = await getAuthenticatedUser(request);
   return user !== null;
 }

--- a/app/lib/static-mode.ts
+++ b/app/lib/static-mode.ts
@@ -1,10 +1,13 @@
 // ABOUTME: Detects whether the app is running in static mode (no Supabase).
-// ABOUTME: Returns true when the Supabase database URL environment variable is not set.
+// ABOUTME: Returns true when required Supabase environment variables are missing or empty.
 
 export function isStaticMode(): boolean {
+  // Server-side uses non-prefixed env vars; browser uses VITE-prefixed (only VITE_ vars are exposed to the client bundle)
   if (typeof process !== "undefined" && process.env) {
-    // Server-side uses non-prefixed env vars; browser uses VITE-prefixed (only VITE_ vars are exposed to the client bundle)
-    return !process.env.SUPABASE_DATABASE_URL;
+    return !process.env.SUPABASE_DATABASE_URL || !process.env.SUPABASE_ANON_KEY;
   }
-  return !import.meta.env.VITE_SUPABASE_DATABASE_URL;
+  return (
+    !import.meta.env.VITE_SUPABASE_DATABASE_URL ||
+    !import.meta.env.VITE_SUPABASE_ANON_KEY
+  );
 }

--- a/app/lib/static-mode.ts
+++ b/app/lib/static-mode.ts
@@ -1,8 +1,9 @@
 // ABOUTME: Detects whether the app is running in static mode (no Supabase).
-// ABOUTME: Returns true when Supabase environment variables are not set.
+// ABOUTME: Returns true when the Supabase database URL environment variable is not set.
 
 export function isStaticMode(): boolean {
   if (typeof process !== "undefined" && process.env) {
+    // Server-side uses non-prefixed env vars; browser uses VITE-prefixed (only VITE_ vars are exposed to the client bundle)
     return !process.env.SUPABASE_DATABASE_URL;
   }
   return !import.meta.env.VITE_SUPABASE_DATABASE_URL;

--- a/app/lib/static-mode.ts
+++ b/app/lib/static-mode.ts
@@ -1,0 +1,9 @@
+// ABOUTME: Detects whether the app is running in static mode (no Supabase).
+// ABOUTME: Returns true when Supabase environment variables are not set.
+
+export function isStaticMode(): boolean {
+  if (typeof process !== "undefined" && process.env) {
+    return !process.env.SUPABASE_DATABASE_URL;
+  }
+  return !import.meta.env.VITE_SUPABASE_DATABASE_URL;
+}

--- a/app/lib/supabase/client.ts
+++ b/app/lib/supabase/client.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Supabase client factory for server-side and browser contexts.
+// ABOUTME: Throws a descriptive error when called in static mode (no Supabase configured).
+
 import {
   createBrowserClient,
   createServerClient,
@@ -5,6 +8,7 @@ import {
   serializeCookieHeader,
 } from "@supabase/ssr";
 
+import { isStaticMode } from "~/lib/static-mode";
 import type { Database } from "~/types/supabase";
 
 export function createClient(request: Request | null = null) {
@@ -13,6 +17,11 @@ export function createClient(request: Request | null = null) {
     const anonKey = process.env.SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !anonKey) {
+      if (isStaticMode()) {
+        throw new Error(
+          "Supabase client unavailable: application is running in static mode",
+        );
+      }
       throw new Error(
         "SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY environment variables are required",
       );
@@ -45,6 +54,11 @@ export function createClient(request: Request | null = null) {
     const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !anonKey) {
+      if (isStaticMode()) {
+        throw new Error(
+          "Supabase client unavailable: application is running in static mode",
+        );
+      }
       throw new Error(
         "VITE_SUPABASE_DATABASE_URL and VITE_SUPABASE_ANON_KEY environment variables are required",
       );

--- a/app/repositories/__tests__/factory.test.ts
+++ b/app/repositories/__tests__/factory.test.ts
@@ -1,0 +1,92 @@
+// ABOUTME: Tests for repository factory functions that select static or live implementations.
+// ABOUTME: Verifies correct provider is returned based on isStaticMode result.
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+// Mock the static-mode module before importing factory
+vi.mock("~/lib/static-mode", () => ({
+  isStaticMode: vi.fn(),
+}));
+
+// Mock the live repositories to avoid needing Supabase
+vi.mock("~/repositories/HeroRepository", () => ({
+  HeroRepository: class MockHeroRepository {
+    type = "live-hero";
+  },
+}));
+
+vi.mock("~/repositories/EquipmentRepository", () => ({
+  EquipmentRepository: class MockEquipmentRepository {
+    type = "live-equipment";
+  },
+}));
+
+vi.mock("~/repositories/MissionRepository", () => ({
+  MissionRepository: class MockMissionRepository {
+    type = "live-mission";
+  },
+}));
+
+import { isStaticMode } from "~/lib/static-mode";
+import {
+  createHeroRepository,
+  createEquipmentRepository,
+  createMissionRepository,
+} from "../factory";
+import { StaticHeroProvider } from "../static/StaticHeroProvider";
+import { StaticEquipmentProvider } from "../static/StaticEquipmentProvider";
+import { StaticMissionProvider } from "../static/StaticMissionProvider";
+
+const mockIsStaticMode = vi.mocked(isStaticMode);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createHeroRepository", () => {
+  it("returns a StaticHeroProvider when in static mode", () => {
+    mockIsStaticMode.mockReturnValue(true);
+    const request = new Request("http://localhost/");
+    const repo = createHeroRepository(request);
+    expect(repo).toBeInstanceOf(StaticHeroProvider);
+  });
+
+  it("returns a HeroRepository when not in static mode", () => {
+    mockIsStaticMode.mockReturnValue(false);
+    const request = new Request("http://localhost/");
+    const repo = createHeroRepository(request);
+    expect(repo).not.toBeInstanceOf(StaticHeroProvider);
+  });
+});
+
+describe("createEquipmentRepository", () => {
+  it("returns a StaticEquipmentProvider when in static mode", () => {
+    mockIsStaticMode.mockReturnValue(true);
+    const request = new Request("http://localhost/");
+    const repo = createEquipmentRepository(request);
+    expect(repo).toBeInstanceOf(StaticEquipmentProvider);
+  });
+
+  it("returns an EquipmentRepository when not in static mode", () => {
+    mockIsStaticMode.mockReturnValue(false);
+    const request = new Request("http://localhost/");
+    const repo = createEquipmentRepository(request);
+    expect(repo).not.toBeInstanceOf(StaticEquipmentProvider);
+  });
+});
+
+describe("createMissionRepository", () => {
+  it("returns a StaticMissionProvider when in static mode", () => {
+    mockIsStaticMode.mockReturnValue(true);
+    const request = new Request("http://localhost/");
+    const repo = createMissionRepository(request);
+    expect(repo).toBeInstanceOf(StaticMissionProvider);
+  });
+
+  it("returns a MissionRepository when not in static mode", () => {
+    mockIsStaticMode.mockReturnValue(false);
+    const request = new Request("http://localhost/");
+    const repo = createMissionRepository(request);
+    expect(repo).not.toBeInstanceOf(StaticMissionProvider);
+  });
+});

--- a/app/repositories/factory.ts
+++ b/app/repositories/factory.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Factory functions that return static providers or live repositories.
+// ABOUTME: Uses isStaticMode() to determine which implementation to use.
+
+import { isStaticMode } from "~/lib/static-mode";
+import { EquipmentRepository } from "~/repositories/EquipmentRepository";
+import { HeroRepository } from "~/repositories/HeroRepository";
+import { MissionRepository } from "~/repositories/MissionRepository";
+import {
+  StaticEquipmentProvider,
+  StaticHeroProvider,
+  StaticMissionProvider,
+} from "~/repositories/static";
+
+export function createHeroRepository(
+  request: Request,
+): HeroRepository | StaticHeroProvider {
+  if (isStaticMode()) return new StaticHeroProvider();
+  return new HeroRepository(request);
+}
+
+export function createEquipmentRepository(
+  request: Request,
+): EquipmentRepository | StaticEquipmentProvider {
+  if (isStaticMode()) return new StaticEquipmentProvider();
+  return new EquipmentRepository(request);
+}
+
+export function createMissionRepository(
+  request: Request,
+): MissionRepository | StaticMissionProvider {
+  if (isStaticMode()) return new StaticMissionProvider();
+  return new MissionRepository(request);
+}

--- a/app/repositories/static/StaticEquipmentProvider.ts
+++ b/app/repositories/static/StaticEquipmentProvider.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Static provider that serves equipment data from the JSON file on disk.
 // ABOUTME: Used in static mode when Supabase environment variables are not set.
 
+import log from "loglevel";
+
 import equipmentsJson from "~/data/equipments.json";
 import {
   EQUIPMENT_QUALITIES,
@@ -50,6 +52,12 @@ function sortByQuality(rows: EquipmentRow[]): EquipmentRow[] {
 }
 
 export class StaticEquipmentProvider {
+  constructor() {
+    log.info(
+      "StaticEquipmentProvider: serving equipment data from static JSON files",
+    );
+  }
+
   async findAll(): Promise<RepositoryResult<EquipmentRow[]>> {
     const rows = sortByQuality(equipments.map(mapRecordToRow));
     return { data: rows, error: null };
@@ -86,34 +94,160 @@ export class StaticEquipmentProvider {
     return { data: sorted, error: null };
   }
 
-  // Relationship queries return empty results in static mode — no relational data available
+  // Relationship queries implemented via in-memory crafting data from equipments.json.
+
+  // Find all equipment whose crafting recipe includes the given slug as a required item.
   async findEquipmentThatRequires(
-    _slug: string,
+    slug: string,
   ): Promise<
     RepositoryResult<Array<{ equipment: EquipmentRow; quantity: number }>>
   > {
-    return { data: [], error: null };
+    const results: Array<{ equipment: EquipmentRow; quantity: number }> = [];
+    for (const record of equipments) {
+      if (!("crafting" in record) || !record.crafting?.required_items) continue;
+      const qty = (record.crafting.required_items as Record<string, number>)[
+        slug
+      ];
+      if (qty !== undefined) {
+        results.push({ equipment: mapRecordToRow(record), quantity: qty });
+      }
+    }
+    return { data: results, error: null };
   }
 
+  // Return the direct crafting ingredients of the given equipment (by slug or row).
   async findEquipmentRequiredFor(
-    _slugOrEquipment: string | EquipmentRow,
+    slugOrEquipment: string | EquipmentRow,
   ): Promise<
     RepositoryResult<Array<{ equipment: EquipmentRow; quantity: number }>>
   > {
-    return { data: [], error: null };
+    const slug =
+      typeof slugOrEquipment === "string"
+        ? slugOrEquipment
+        : slugOrEquipment.slug;
+    const record = equipments.find((r) => r.slug === slug);
+    if (
+      !record ||
+      !("crafting" in record) ||
+      !record.crafting?.required_items
+    ) {
+      return { data: [], error: null };
+    }
+    const requiredItems = record.crafting.required_items as Record<
+      string,
+      number
+    >;
+    const results: Array<{ equipment: EquipmentRow; quantity: number }> = [];
+    for (const [reqSlug, qty] of Object.entries(requiredItems)) {
+      const reqRecord = equipments.find((r) => r.slug === reqSlug);
+      if (reqRecord) {
+        results.push({ equipment: mapRecordToRow(reqRecord), quantity: qty });
+      }
+    }
+    return { data: results, error: null };
   }
 
   async findEquipmentRequiredForRaw(
-    _equipment: EquipmentRow,
+    equipment: EquipmentRow,
   ): Promise<RepositoryResult<EquipmentRequirements | null>> {
-    return { data: null, error: null };
+    const record = equipments.find((r) => r.slug === equipment.slug);
+    if (
+      !record ||
+      !("crafting" in record) ||
+      !record.crafting?.required_items
+    ) {
+      return { data: null, error: null };
+    }
+    const baseItems: EquipmentRequirements = {
+      gold_cost: 0,
+      required_items: [],
+    };
+    const crafting = record.crafting as {
+      gold_cost: number;
+      required_items: Record<string, number>;
+    };
+    baseItems.gold_cost += crafting.gold_cost;
+    for (const [reqSlug, qty] of Object.entries(crafting.required_items)) {
+      const reqRecord = equipments.find((r) => r.slug === reqSlug);
+      if (!reqRecord) continue;
+      const reqRow = mapRecordToRow(reqRecord);
+      // If the required item also has crafting, recurse to get raw components
+      if ("crafting" in reqRecord && reqRecord.crafting) {
+        const rawResult = await this.findEquipmentRequiredForRaw(reqRow);
+        if (rawResult.data) {
+          baseItems.gold_cost += rawResult.data.gold_cost * qty;
+          for (const raw of rawResult.data.required_items) {
+            const existing = baseItems.required_items.find(
+              (ri) => ri.equipment.slug === raw.equipment.slug,
+            );
+            if (existing) {
+              existing.quantity += raw.quantity * qty;
+            } else {
+              baseItems.required_items.push({
+                ...raw,
+                quantity: raw.quantity * qty,
+              });
+            }
+          }
+        }
+      } else {
+        const existing = baseItems.required_items.find(
+          (ri) => ri.equipment.slug === reqRow.slug,
+        );
+        if (existing) {
+          existing.quantity += qty;
+        } else {
+          baseItems.required_items.push({ equipment: reqRow, quantity: qty });
+        }
+      }
+    }
+    return { data: baseItems, error: null };
   }
 
+  // Walk the crafting tree upward to find all final products (non-craftable equipables) that use this slug.
   async findRawComponentOf(
-    _slug: string,
+    slug: string,
   ): Promise<
     RepositoryResult<Array<{ equipment: EquipmentRow; totalQuantity: number }>>
   > {
-    return { data: [], error: null };
+    const finalProducts = new Map<
+      string,
+      { equipment: EquipmentRow; totalQuantity: number }
+    >();
+
+    const traverse = async (
+      componentSlug: string,
+      multiplier: number,
+      path: string[],
+    ): Promise<void> => {
+      if (path.includes(componentSlug)) return;
+      const newPath = [...path, componentSlug];
+
+      const requiredForResult =
+        await this.findEquipmentThatRequires(componentSlug);
+      if (!requiredForResult.data?.length) return;
+
+      for (const { equipment, quantity } of requiredForResult.data) {
+        const newMultiplier = multiplier * quantity;
+        const nextResult = await this.findEquipmentThatRequires(equipment.slug);
+        if (!nextResult.data?.length) {
+          // This is a final product
+          const existing = finalProducts.get(equipment.slug);
+          if (existing) {
+            existing.totalQuantity += newMultiplier;
+          } else {
+            finalProducts.set(equipment.slug, {
+              equipment,
+              totalQuantity: newMultiplier,
+            });
+          }
+        } else {
+          await traverse(equipment.slug, newMultiplier, newPath);
+        }
+      }
+    };
+
+    await traverse(slug, 1, []);
+    return { data: Array.from(finalProducts.values()), error: null };
   }
 }

--- a/app/repositories/static/StaticEquipmentProvider.ts
+++ b/app/repositories/static/StaticEquipmentProvider.ts
@@ -14,9 +14,9 @@ import type { Database } from "~/types/supabase";
 
 type EquipmentRow = Database["public"]["Tables"]["equipment"]["Row"];
 
-// The equipments.json records already closely match EquipmentRecord shape.
-// We cast them via unknown since the JSON loader types don't exactly match but
-// the runtime data is compatible.
+// The equipments.json records match EquipmentRecord shape at runtime but TypeScript's
+// JSON import types are generic; the cast via unknown bridges that type gap without
+// losing type safety in the rest of the file.
 const equipments = equipmentsJson as unknown as EquipmentRecord[];
 
 function mapRecordToRow(record: EquipmentRecord): EquipmentRow {
@@ -169,7 +169,12 @@ export class StaticEquipmentProvider {
     baseItems.gold_cost += crafting.gold_cost;
     for (const [reqSlug, qty] of Object.entries(crafting.required_items)) {
       const reqRecord = equipments.find((r) => r.slug === reqSlug);
-      if (!reqRecord) continue;
+      if (!reqRecord) {
+        log.warn(
+          `StaticEquipmentProvider: crafting ingredient "${reqSlug}" not found in equipment data`,
+        );
+        continue;
+      }
       const reqRow = mapRecordToRow(reqRecord);
       // If the required item also has crafting, recurse to get raw components
       if ("crafting" in reqRecord && reqRecord.crafting) {
@@ -204,7 +209,7 @@ export class StaticEquipmentProvider {
     return { data: baseItems, error: null };
   }
 
-  // Walk the crafting tree upward to find all final products (non-craftable equipables) that use this slug.
+  // Walk the crafting tree upward to find all final products (equipment not used as an ingredient in other recipes) that use this slug.
   async findRawComponentOf(
     slug: string,
   ): Promise<

--- a/app/repositories/static/StaticEquipmentProvider.ts
+++ b/app/repositories/static/StaticEquipmentProvider.ts
@@ -6,6 +6,7 @@ import {
   EQUIPMENT_QUALITIES,
   type EquipmentRecord,
 } from "~/data/equipment.zod";
+import type { EquipmentRequirements } from "~/repositories/EquipmentRepository";
 import type { RepositoryResult } from "~/repositories/types";
 import type { Database } from "~/types/supabase";
 
@@ -54,6 +55,17 @@ export class StaticEquipmentProvider {
     return { data: rows, error: null };
   }
 
+  async findById(slug: string): Promise<RepositoryResult<EquipmentRow>> {
+    const record = equipments.find((r) => r.slug === slug);
+    if (!record) {
+      return {
+        data: null,
+        error: { message: `Equipment not found: ${slug}`, code: "NOT_FOUND" },
+      };
+    }
+    return { data: mapRecordToRow(record), error: null };
+  }
+
   async getAllAsJson(
     ids?: string[],
   ): Promise<RepositoryResult<EquipmentRecord[]>> {
@@ -72,5 +84,36 @@ export class StaticEquipmentProvider {
     });
 
     return { data: sorted, error: null };
+  }
+
+  // Relationship queries return empty results in static mode — no relational data available
+  async findEquipmentThatRequires(
+    _slug: string,
+  ): Promise<
+    RepositoryResult<Array<{ equipment: EquipmentRow; quantity: number }>>
+  > {
+    return { data: [], error: null };
+  }
+
+  async findEquipmentRequiredFor(
+    _slugOrEquipment: string | EquipmentRow,
+  ): Promise<
+    RepositoryResult<Array<{ equipment: EquipmentRow; quantity: number }>>
+  > {
+    return { data: [], error: null };
+  }
+
+  async findEquipmentRequiredForRaw(
+    _equipment: EquipmentRow,
+  ): Promise<RepositoryResult<EquipmentRequirements | null>> {
+    return { data: null, error: null };
+  }
+
+  async findRawComponentOf(
+    _slug: string,
+  ): Promise<
+    RepositoryResult<Array<{ equipment: EquipmentRow; totalQuantity: number }>>
+  > {
+    return { data: [], error: null };
   }
 }

--- a/app/repositories/static/StaticEquipmentProvider.ts
+++ b/app/repositories/static/StaticEquipmentProvider.ts
@@ -1,0 +1,76 @@
+// ABOUTME: Static provider that serves equipment data from the JSON file on disk.
+// ABOUTME: Used in static mode when Supabase environment variables are not set.
+
+import equipmentsJson from "~/data/equipments.json";
+import {
+  EQUIPMENT_QUALITIES,
+  type EquipmentRecord,
+} from "~/data/equipment.zod";
+import type { RepositoryResult } from "~/repositories/types";
+import type { Database } from "~/types/supabase";
+
+type EquipmentRow = Database["public"]["Tables"]["equipment"]["Row"];
+
+// The equipments.json records already closely match EquipmentRecord shape.
+// We cast them via unknown since the JSON loader types don't exactly match but
+// the runtime data is compatible.
+const equipments = equipmentsJson as unknown as EquipmentRecord[];
+
+function mapRecordToRow(record: EquipmentRecord): EquipmentRow {
+  return {
+    slug: record.slug,
+    name: record.name,
+    quality: record.quality,
+    type: record.type,
+    sell_value: record.sell_value,
+    guild_activity_points: record.guild_activity_points,
+    buy_value_gold: record.buy_value_gold ?? null,
+    buy_value_coin: record.buy_value_coin ?? null,
+    campaign_sources: record.campaign_sources ?? null,
+    crafting_gold_cost:
+      "crafting" in record && record.crafting
+        ? record.crafting.gold_cost
+        : null,
+    hero_level_required:
+      "hero_level_required" in record
+        ? (record.hero_level_required ?? null)
+        : null,
+    image_hash: null,
+  };
+}
+
+function sortByQuality(rows: EquipmentRow[]): EquipmentRow[] {
+  return [...rows].sort((l, r) => {
+    const lIdx = EQUIPMENT_QUALITIES.indexOf(l.quality);
+    const rIdx = EQUIPMENT_QUALITIES.indexOf(r.quality);
+    if (lIdx !== rIdx) return lIdx - rIdx;
+    return l.name.localeCompare(r.name);
+  });
+}
+
+export class StaticEquipmentProvider {
+  async findAll(): Promise<RepositoryResult<EquipmentRow[]>> {
+    const rows = sortByQuality(equipments.map(mapRecordToRow));
+    return { data: rows, error: null };
+  }
+
+  async getAllAsJson(
+    ids?: string[],
+  ): Promise<RepositoryResult<EquipmentRecord[]>> {
+    let records = equipments;
+
+    if (ids && ids.length > 0) {
+      records = records.filter((r) => ids.includes(r.slug));
+    }
+
+    // Sort using quality ordering, same as live repository
+    const sorted = [...records].sort((l, r) => {
+      const lIdx = EQUIPMENT_QUALITIES.indexOf(l.quality);
+      const rIdx = EQUIPMENT_QUALITIES.indexOf(r.quality);
+      if (lIdx !== rIdx) return lIdx - rIdx;
+      return l.name.localeCompare(r.name);
+    });
+
+    return { data: sorted, error: null };
+  }
+}

--- a/app/repositories/static/StaticHeroProvider.ts
+++ b/app/repositories/static/StaticHeroProvider.ts
@@ -1,0 +1,200 @@
+// ABOUTME: Static provider that serves hero data from the JSON file on disk.
+// ABOUTME: Used in static mode when Supabase environment variables are not set.
+
+import heroesJson from "~/data/heroes.json";
+import type {
+  CompleteHero,
+  Hero,
+  HeroArtifact,
+  HeroEquipmentSlot,
+  HeroGlyph,
+  HeroSkin,
+  RepositoryResult,
+} from "~/repositories/types";
+
+// Shape of a hero record in heroes.json
+interface HeroJsonRecord {
+  slug: string;
+  name: string;
+  class: string;
+  faction: string;
+  main_stat: string;
+  attack_type?: string[];
+  stone_source?: string[];
+  order_rank?: number;
+  updated_on?: string;
+  artifacts?: {
+    weapon?: { name: string; team_buff: string; team_buff_secondary?: string };
+    book?: string;
+    ring?: null;
+  };
+  skins?: Array<{
+    name: string;
+    stat: string;
+    has_plus?: boolean;
+    source?: string;
+  }>;
+  glyphs?: (string | null)[];
+  items?: Record<string, (string | null)[]>;
+}
+
+function mapJsonToHeroRow(json: HeroJsonRecord): Hero {
+  return {
+    slug: json.slug,
+    name: json.name,
+    class: json.class,
+    faction: json.faction,
+    main_stat: json.main_stat,
+    attack_type: json.attack_type ?? [],
+    stone_source: json.stone_source ?? [],
+    order_rank: json.order_rank ?? 0,
+    updated_on: json.updated_on ?? null,
+  };
+}
+
+function mapJsonToArtifacts(json: HeroJsonRecord): HeroArtifact[] {
+  if (!json.artifacts) return [];
+
+  const artifacts: HeroArtifact[] = [];
+
+  if (json.artifacts.weapon) {
+    artifacts.push({
+      id: `${json.slug}-weapon`,
+      hero_slug: json.slug,
+      artifact_type: "weapon",
+      name: json.artifacts.weapon.name,
+      team_buff: json.artifacts.weapon.team_buff,
+      team_buff_secondary: json.artifacts.weapon.team_buff_secondary ?? null,
+      created_at: null,
+    });
+  }
+
+  if (json.artifacts.book !== undefined) {
+    artifacts.push({
+      id: `${json.slug}-book`,
+      hero_slug: json.slug,
+      artifact_type: "book",
+      name: json.artifacts.book,
+      team_buff: null,
+      team_buff_secondary: null,
+      created_at: null,
+    });
+  }
+
+  if ("ring" in json.artifacts) {
+    artifacts.push({
+      id: `${json.slug}-ring`,
+      hero_slug: json.slug,
+      artifact_type: "ring",
+      name: null,
+      team_buff: null,
+      team_buff_secondary: null,
+      created_at: null,
+    });
+  }
+
+  return artifacts;
+}
+
+function mapJsonToSkins(json: HeroJsonRecord): HeroSkin[] {
+  if (!json.skins) return [];
+
+  return json.skins.map((skin, index) => ({
+    id: `${json.slug}-skin-${index}`,
+    hero_slug: json.slug,
+    name: skin.name,
+    stat_type: skin.stat,
+    stat_value: 0,
+    has_plus: skin.has_plus ?? false,
+    source: skin.source ?? null,
+    created_at: null,
+  }));
+}
+
+function mapJsonToGlyphs(json: HeroJsonRecord): HeroGlyph[] {
+  if (!json.glyphs) return [];
+
+  const result: HeroGlyph[] = [];
+  json.glyphs.forEach((stat, index) => {
+    if (stat === null) return;
+    result.push({
+      id: `${json.slug}-glyph-${index + 1}`,
+      hero_slug: json.slug,
+      position: index + 1,
+      stat_type: stat,
+      stat_value: 0,
+      created_at: null,
+    });
+  });
+  return result;
+}
+
+function mapJsonToEquipmentSlots(json: HeroJsonRecord): HeroEquipmentSlot[] {
+  if (!json.items) return [];
+
+  const slots: HeroEquipmentSlot[] = [];
+  let idCounter = 0;
+
+  for (const [quality, equipmentList] of Object.entries(json.items)) {
+    if (!Array.isArray(equipmentList)) continue;
+    equipmentList.forEach((equipSlug, slotIndex) => {
+      idCounter++;
+      slots.push({
+        id: `${json.slug}-slot-${idCounter}`,
+        hero_slug: json.slug,
+        quality,
+        slot_position: slotIndex + 1,
+        equipment_slug: equipSlug ?? null,
+        created_at: null,
+      });
+    });
+  }
+
+  return slots;
+}
+
+function buildCompleteHero(json: HeroJsonRecord): CompleteHero {
+  return {
+    ...mapJsonToHeroRow(json),
+    artifacts: mapJsonToArtifacts(json),
+    skins: mapJsonToSkins(json),
+    glyphs: mapJsonToGlyphs(json).sort((a, b) => a.position - b.position),
+    equipmentSlots: mapJsonToEquipmentSlots(json),
+  };
+}
+
+export class StaticHeroProvider {
+  private readonly heroes: HeroJsonRecord[] = heroesJson as HeroJsonRecord[];
+
+  async findAll(): Promise<RepositoryResult<Hero[]>> {
+    const rows = this.heroes
+      .map(mapJsonToHeroRow)
+      .sort((a, b) => a.order_rank - b.order_rank);
+
+    return { data: rows, error: null };
+  }
+
+  async findWithAllData(slug: string): Promise<RepositoryResult<CompleteHero>> {
+    const json = this.heroes.find((h) => h.slug === slug);
+
+    if (!json) {
+      return {
+        data: null,
+        error: {
+          message: `Hero not found: ${slug}`,
+          code: "NOT_FOUND",
+        },
+      };
+    }
+
+    return { data: buildCompleteHero(json), error: null };
+  }
+
+  async findAllWithRelationships(): Promise<RepositoryResult<CompleteHero[]>> {
+    const completeHeroes = this.heroes
+      .map(buildCompleteHero)
+      .sort((a, b) => a.order_rank - b.order_rank);
+
+    return { data: completeHeroes, error: null };
+  }
+}

--- a/app/repositories/static/StaticHeroProvider.ts
+++ b/app/repositories/static/StaticHeroProvider.ts
@@ -174,6 +174,17 @@ export class StaticHeroProvider {
     return { data: rows, error: null };
   }
 
+  async findById(slug: string): Promise<RepositoryResult<Hero>> {
+    const json = this.heroes.find((h) => h.slug === slug);
+    if (!json) {
+      return {
+        data: null,
+        error: { message: `Hero not found: ${slug}`, code: "NOT_FOUND" },
+      };
+    }
+    return { data: mapJsonToHeroRow(json), error: null };
+  }
+
   async findWithAllData(slug: string): Promise<RepositoryResult<CompleteHero>> {
     const json = this.heroes.find((h) => h.slug === slug);
 
@@ -196,5 +207,12 @@ export class StaticHeroProvider {
       .sort((a, b) => a.order_rank - b.order_rank);
 
     return { data: completeHeroes, error: null };
+  }
+
+  // Returns empty results in static mode — relational queries are not available
+  async findHeroesUsingEquipment(
+    _equipmentSlug: string,
+  ): Promise<RepositoryResult<Hero[]>> {
+    return { data: [], error: null };
   }
 }

--- a/app/repositories/static/StaticHeroProvider.ts
+++ b/app/repositories/static/StaticHeroProvider.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Static provider that serves hero data from the JSON file on disk.
 // ABOUTME: Used in static mode when Supabase environment variables are not set.
 
+import log from "loglevel";
+
 import heroesJson from "~/data/heroes.json";
 import type {
   CompleteHero,
@@ -166,6 +168,10 @@ function buildCompleteHero(json: HeroJsonRecord): CompleteHero {
 export class StaticHeroProvider {
   private readonly heroes: HeroJsonRecord[] = heroesJson as HeroJsonRecord[];
 
+  constructor() {
+    log.info("StaticHeroProvider: serving hero data from static JSON files");
+  }
+
   async findAll(): Promise<RepositoryResult<Hero[]>> {
     const rows = this.heroes
       .map(mapJsonToHeroRow)
@@ -209,10 +215,16 @@ export class StaticHeroProvider {
     return { data: completeHeroes, error: null };
   }
 
-  // Returns empty results in static mode — relational queries are not available
+  // Reverse-lookup: iterate all heroes and check if any equipment slot matches the given slug.
   async findHeroesUsingEquipment(
-    _equipmentSlug: string,
+    equipmentSlug: string,
   ): Promise<RepositoryResult<Hero[]>> {
-    return { data: [], error: null };
+    const matching = this.heroes.filter((json) => {
+      if (!json.items) return false;
+      return Object.values(json.items).some((slots) =>
+        slots.some((slot) => slot === equipmentSlug),
+      );
+    });
+    return { data: matching.map(mapJsonToHeroRow), error: null };
   }
 }

--- a/app/repositories/static/StaticMissionProvider.ts
+++ b/app/repositories/static/StaticMissionProvider.ts
@@ -1,6 +1,9 @@
 // ABOUTME: Static provider that serves mission and chapter data from the JSON file on disk.
 // ABOUTME: Used in static mode when Supabase environment variables are not set.
 
+import log from "loglevel";
+
+import equipmentsJson from "~/data/equipments.json";
 import missionsJson from "~/data/missions.json";
 import type { RepositoryResult } from "~/repositories/types";
 import type { Chapter, Mission } from "~/repositories/MissionRepository";
@@ -15,6 +18,11 @@ interface MissionsJsonData {
   }>;
 }
 
+interface EquipmentJsonRecord {
+  slug: string;
+  campaign_sources?: string[];
+}
+
 interface OrderByOption {
   column: string;
   ascending?: boolean;
@@ -25,6 +33,7 @@ interface FindAllOptions {
 }
 
 const jsonData = missionsJson as MissionsJsonData;
+const equipmentData = equipmentsJson as unknown as EquipmentJsonRecord[];
 
 function parseMissionSlug(slug: string): { chapter_id: number; level: number } {
   const parts = slug.split("-");
@@ -58,6 +67,12 @@ function sortMissions(missions: Mission[]): Mission[] {
 }
 
 export class StaticMissionProvider {
+  constructor() {
+    log.info(
+      "StaticMissionProvider: serving mission data from static JSON files",
+    );
+  }
+
   async findAll(
     options?: FindAllOptions,
   ): Promise<RepositoryResult<Mission[]>> {
@@ -107,10 +122,21 @@ export class StaticMissionProvider {
   async findByCampaignSource(
     equipmentSlug: string,
   ): Promise<RepositoryResult<Mission[]>> {
-    // Campaign source data is embedded in equipment records; without the equipment JSON
-    // relationship mapping, we return all missions that list this slug and filter at the
-    // equipment level. Since static equipment is already filtered in the route, return empty.
-    void equipmentSlug;
-    return { data: [], error: null };
+    // Look up the equipment record by slug to retrieve its campaign_sources mission slugs,
+    // then return the corresponding mission rows from the missions JSON.
+    const equipment = equipmentData.find((e) => e.slug === equipmentSlug);
+    if (
+      !equipment?.campaign_sources ||
+      equipment.campaign_sources.length === 0
+    ) {
+      return { data: [], error: null };
+    }
+    const missionSlugs = new Set(equipment.campaign_sources);
+    const missions = sortMissions(
+      jsonData.missions
+        .filter((m) => missionSlugs.has(m.slug))
+        .map(mapJsonToMissionRow),
+    );
+    return { data: missions, error: null };
   }
 }

--- a/app/repositories/static/StaticMissionProvider.ts
+++ b/app/repositories/static/StaticMissionProvider.ts
@@ -44,6 +44,9 @@ function parseMissionSlug(slug: string): { chapter_id: number; level: number } {
       return { chapter_id, level };
     }
   }
+  log.warn(
+    `StaticMissionProvider: could not parse mission slug "${slug}", defaulting to chapter_id=0, level=0`,
+  );
   return { chapter_id: 0, level: 0 };
 }
 
@@ -76,7 +79,7 @@ export class StaticMissionProvider {
   async findAll(
     options?: FindAllOptions,
   ): Promise<RepositoryResult<Mission[]>> {
-    // The options parameter is accepted for interface compatibility with MissionRepository.
+    // The options parameter is accepted for duck-type compatibility with MissionRepository.
     // Static data is always sorted by chapter_id then level by default.
     void options;
     const missions = sortMissions(jsonData.missions.map(mapJsonToMissionRow));

--- a/app/repositories/static/StaticMissionProvider.ts
+++ b/app/repositories/static/StaticMissionProvider.ts
@@ -1,0 +1,75 @@
+// ABOUTME: Static provider that serves mission and chapter data from the JSON file on disk.
+// ABOUTME: Used in static mode when Supabase environment variables are not set.
+
+import missionsJson from "~/data/missions.json";
+import type { RepositoryResult } from "~/repositories/types";
+import type { Chapter, Mission } from "~/repositories/MissionRepository";
+
+interface MissionsJsonData {
+  chapters: Array<{ id: number; title: string }>;
+  missions: Array<{
+    slug: string;
+    name: string;
+    hero_slug?: string;
+    energy_cost?: number;
+  }>;
+}
+
+interface OrderByOption {
+  column: string;
+  ascending?: boolean;
+}
+
+interface FindAllOptions {
+  orderBy?: OrderByOption | OrderByOption[];
+}
+
+const jsonData = missionsJson as MissionsJsonData;
+
+function parseMissionSlug(slug: string): { chapter_id: number; level: number } {
+  const parts = slug.split("-");
+  if (parts.length >= 2) {
+    const chapter_id = parseInt(parts[0], 10);
+    const level = parseInt(parts[1], 10);
+    if (!isNaN(chapter_id) && !isNaN(level)) {
+      return { chapter_id, level };
+    }
+  }
+  return { chapter_id: 0, level: 0 };
+}
+
+function mapJsonToMissionRow(json: MissionsJsonData["missions"][0]): Mission {
+  const { chapter_id, level } = parseMissionSlug(json.slug);
+  return {
+    slug: json.slug,
+    name: json.name,
+    chapter_id,
+    level,
+    hero_slug: json.hero_slug ?? null,
+    energy_cost: json.energy_cost ?? null,
+  };
+}
+
+function sortMissions(missions: Mission[]): Mission[] {
+  return [...missions].sort((a, b) => {
+    if (a.chapter_id !== b.chapter_id) return a.chapter_id - b.chapter_id;
+    return (a.level ?? 0) - (b.level ?? 0);
+  });
+}
+
+export class StaticMissionProvider {
+  async findAll(
+    options?: FindAllOptions,
+  ): Promise<RepositoryResult<Mission[]>> {
+    // The options parameter is accepted for interface compatibility with MissionRepository.
+    // Static data is always sorted by chapter_id then level by default.
+    void options;
+    const missions = sortMissions(jsonData.missions.map(mapJsonToMissionRow));
+    return { data: missions, error: null };
+  }
+
+  async findAllChapters(): Promise<RepositoryResult<Chapter[]>> {
+    const chapters = [...jsonData.chapters].sort((a, b) => a.id - b.id);
+    return { data: chapters, error: null };
+  }
+}

--- a/app/repositories/static/StaticMissionProvider.ts
+++ b/app/repositories/static/StaticMissionProvider.ts
@@ -68,8 +68,49 @@ export class StaticMissionProvider {
     return { data: missions, error: null };
   }
 
+  async findById(slug: string): Promise<RepositoryResult<Mission>> {
+    const raw = jsonData.missions.find((m) => m.slug === slug);
+    if (!raw) {
+      return {
+        data: null,
+        error: { message: `Mission not found: ${slug}`, code: "NOT_FOUND" },
+      };
+    }
+    return { data: mapJsonToMissionRow(raw), error: null };
+  }
+
   async findAllChapters(): Promise<RepositoryResult<Chapter[]>> {
     const chapters = [...jsonData.chapters].sort((a, b) => a.id - b.id);
     return { data: chapters, error: null };
+  }
+
+  async findChapterById(id: number): Promise<RepositoryResult<Chapter>> {
+    const chapter = jsonData.chapters.find((c) => c.id === id);
+    if (!chapter) {
+      return {
+        data: null,
+        error: { message: `Chapter not found: ${id}`, code: "NOT_FOUND" },
+      };
+    }
+    return { data: chapter, error: null };
+  }
+
+  async findByHeroSlug(heroSlug: string): Promise<RepositoryResult<Mission[]>> {
+    const missions = sortMissions(
+      jsonData.missions
+        .filter((m) => m.hero_slug === heroSlug)
+        .map(mapJsonToMissionRow),
+    );
+    return { data: missions, error: null };
+  }
+
+  async findByCampaignSource(
+    equipmentSlug: string,
+  ): Promise<RepositoryResult<Mission[]>> {
+    // Campaign source data is embedded in equipment records; without the equipment JSON
+    // relationship mapping, we return all missions that list this slug and filter at the
+    // equipment level. Since static equipment is already filtered in the route, return empty.
+    void equipmentSlug;
+    return { data: [], error: null };
   }
 }

--- a/app/repositories/static/__tests__/StaticEquipmentProvider.test.ts
+++ b/app/repositories/static/__tests__/StaticEquipmentProvider.test.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Tests for StaticEquipmentProvider — verifies equipment data served from JSON files.
+// ABOUTME: Covers findAll and getAllAsJson methods.
+
+import { describe, expect, it } from "vitest";
+
+import { StaticEquipmentProvider } from "../StaticEquipmentProvider";
+
+describe("StaticEquipmentProvider", () => {
+  const provider = new StaticEquipmentProvider();
+
+  describe("findAll", () => {
+    it("returns a list of equipment without errors", async () => {
+      const result = await provider.findAll();
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it("returns equipment with required DB row fields", async () => {
+      const result = await provider.findAll();
+      const items = result.data!;
+      expect(items.length).toBeGreaterThan(0);
+      const first = items[0];
+      expect(first).toHaveProperty("slug");
+      expect(first).toHaveProperty("name");
+      expect(first).toHaveProperty("quality");
+      expect(first).toHaveProperty("type");
+      expect(first).toHaveProperty("sell_value");
+      expect(first).toHaveProperty("guild_activity_points");
+    });
+
+    it("returns equipment sorted by quality then name", async () => {
+      const result = await provider.findAll();
+      const items = result.data!;
+      const qualityOrder = ["gray", "green", "blue", "violet", "orange"];
+      // First item should be gray quality (lowest)
+      expect(qualityOrder.indexOf(items[0].quality)).toBeLessThanOrEqual(
+        qualityOrder.indexOf(items[items.length - 1].quality),
+      );
+    });
+  });
+
+  describe("getAllAsJson", () => {
+    it("returns EquipmentRecord array without errors", async () => {
+      const result = await provider.getAllAsJson();
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it("returns the same count as findAll", async () => {
+      const allResult = await provider.findAll();
+      const jsonResult = await provider.getAllAsJson();
+      expect(jsonResult.data!.length).toBe(allResult.data!.length);
+    });
+
+    it("returns records with slug and name fields", async () => {
+      const result = await provider.getAllAsJson();
+      const items = result.data!;
+      expect(items.length).toBeGreaterThan(0);
+      expect(items[0]).toHaveProperty("slug");
+      expect(items[0]).toHaveProperty("name");
+    });
+
+    it("accepts an ids filter to return specific equipment", async () => {
+      const result = await provider.getAllAsJson(["apprentices-mantle"]);
+      expect(result.error).toBeNull();
+      expect(result.data!.length).toBe(1);
+      expect(result.data![0].slug).toBe("apprentices-mantle");
+    });
+
+    it("returns empty array when ids filter matches nothing", async () => {
+      const result = await provider.getAllAsJson(["no-such-item"]);
+      expect(result.error).toBeNull();
+      expect(result.data!.length).toBe(0);
+    });
+  });
+});

--- a/app/repositories/static/__tests__/StaticEquipmentProvider.test.ts
+++ b/app/repositories/static/__tests__/StaticEquipmentProvider.test.ts
@@ -40,6 +40,25 @@ describe("StaticEquipmentProvider", () => {
     });
   });
 
+  describe("findById", () => {
+    it("returns an equipment row for a known slug", async () => {
+      const result = await provider.findById("apprentices-mantle");
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(result.data!.slug).toBe("apprentices-mantle");
+      expect(result.data).toHaveProperty("name");
+      expect(result.data).toHaveProperty("quality");
+      expect(result.data).toHaveProperty("type");
+    });
+
+    it("returns NOT_FOUND error for unknown slug", async () => {
+      const result = await provider.findById("no-such-equipment");
+      expect(result.data).toBeNull();
+      expect(result.error).not.toBeNull();
+      expect(result.error!.code).toBe("NOT_FOUND");
+    });
+  });
+
   describe("getAllAsJson", () => {
     it("returns EquipmentRecord array without errors", async () => {
       const result = await provider.getAllAsJson();

--- a/app/repositories/static/__tests__/StaticEquipmentProvider.test.ts
+++ b/app/repositories/static/__tests__/StaticEquipmentProvider.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for StaticEquipmentProvider — verifies equipment data served from JSON files.
-// ABOUTME: Covers findAll and getAllAsJson methods.
+// ABOUTME: Covers findAll, getAllAsJson, and relationship query methods.
 
 import { describe, expect, it } from "vitest";
 
@@ -92,6 +92,120 @@ describe("StaticEquipmentProvider", () => {
       const result = await provider.getAllAsJson(["no-such-item"]);
       expect(result.error).toBeNull();
       expect(result.data!.length).toBe(0);
+    });
+  });
+
+  // Relationship queries use real equipment data from equipments.json.
+  // crossbow requires: orcish-yatagan (x1) and lucky-arrow (x1) — both are base (non-crafted) items.
+  // lucky-arrow is used in both crossbow and elven-bow.
+  // elven-bow requires: giants-belt (x1, which is itself crafted) and lucky-arrow (x1).
+  // orcish-yatagan is a base ingredient used only in crossbow.
+
+  describe("findEquipmentThatRequires", () => {
+    it("finds parent items that require a known ingredient slug", async () => {
+      // lucky-arrow is used in crossbow and elven-bow
+      const result = await provider.findEquipmentThatRequires("lucky-arrow");
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      const slugs = result.data!.map((r) => r.equipment.slug);
+      expect(slugs).toContain("crossbow");
+      expect(slugs).toContain("elven-bow");
+    });
+
+    it("returns each result with a quantity", async () => {
+      const result = await provider.findEquipmentThatRequires("lucky-arrow");
+      const crossbowEntry = result.data!.find(
+        (r) => r.equipment.slug === "crossbow",
+      );
+      expect(crossbowEntry).toBeDefined();
+      expect(crossbowEntry!.quantity).toBe(1);
+    });
+
+    it("returns empty array for a slug not used in any recipe", async () => {
+      const result =
+        await provider.findEquipmentThatRequires("no-such-ingredient");
+      expect(result.error).toBeNull();
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe("findEquipmentRequiredFor", () => {
+    it("returns direct crafting ingredients with quantities for a crafted item", async () => {
+      // crossbow requires orcish-yatagan and lucky-arrow
+      const result = await provider.findEquipmentRequiredFor("crossbow");
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      const slugs = result.data!.map((r) => r.equipment.slug);
+      expect(slugs).toContain("orcish-yatagan");
+      expect(slugs).toContain("lucky-arrow");
+    });
+
+    it("returns quantity values for each ingredient", async () => {
+      const result = await provider.findEquipmentRequiredFor("crossbow");
+      const entry = result.data!.find(
+        (r) => r.equipment.slug === "orcish-yatagan",
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.quantity).toBe(1);
+    });
+
+    it("returns empty array for equipment with no crafting recipe", async () => {
+      // orcish-yatagan is a base ingredient, not crafted
+      const result = await provider.findEquipmentRequiredFor("orcish-yatagan");
+      expect(result.error).toBeNull();
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe("findEquipmentRequiredForRaw", () => {
+    it("recursively flattens ingredients for a multi-level crafted item", async () => {
+      // elven-bow requires giants-belt (which requires quiver, oil-lamp, travellers-shoes) and lucky-arrow
+      const elvenBowRow = (await provider.findById("elven-bow")).data!;
+      const result = await provider.findEquipmentRequiredForRaw(elvenBowRow);
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      // The raw ingredients should be base items, not giants-belt itself
+      const slugs = result.data!.required_items.map((r) => r.equipment.slug);
+      expect(slugs).not.toContain("giants-belt");
+      // Should include giants-belt's base components
+      expect(slugs).toContain("quiver");
+      expect(slugs).toContain("oil-lamp");
+      expect(slugs).toContain("travellers-shoes");
+      expect(slugs).toContain("lucky-arrow");
+    });
+
+    it("returns null data for equipment with no crafting recipe", async () => {
+      // orcish-yatagan is a base ingredient with no crafting
+      const baseRow = (await provider.findById("orcish-yatagan")).data!;
+      const result = await provider.findEquipmentRequiredForRaw(baseRow);
+      expect(result.error).toBeNull();
+      expect(result.data).toBeNull();
+    });
+  });
+
+  describe("findRawComponentOf", () => {
+    it("finds end products that use a base ingredient", async () => {
+      // orcish-yatagan is only used in crossbow; crossbow is a final product (not used in other recipes)
+      const result = await provider.findRawComponentOf("orcish-yatagan");
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      const slugs = result.data!.map((r) => r.equipment.slug);
+      expect(slugs).toContain("crossbow");
+    });
+
+    it("includes totalQuantity for each end product", async () => {
+      const result = await provider.findRawComponentOf("orcish-yatagan");
+      const crossbowEntry = result.data!.find(
+        (r) => r.equipment.slug === "crossbow",
+      );
+      expect(crossbowEntry).toBeDefined();
+      expect(crossbowEntry!.totalQuantity).toBeGreaterThan(0);
+    });
+
+    it("returns empty array for a slug not used in any recipe", async () => {
+      const result = await provider.findRawComponentOf("no-such-ingredient");
+      expect(result.error).toBeNull();
+      expect(result.data).toEqual([]);
     });
   });
 });

--- a/app/repositories/static/__tests__/StaticHeroProvider.test.ts
+++ b/app/repositories/static/__tests__/StaticHeroProvider.test.ts
@@ -93,6 +93,57 @@ describe("StaticHeroProvider", () => {
     });
   });
 
+  describe("findById", () => {
+    it("returns a Hero row for a known slug", async () => {
+      const result = await provider.findById("aidan");
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(result.data!.slug).toBe("aidan");
+      expect(result.data).toHaveProperty("name");
+      expect(result.data).toHaveProperty("class");
+      expect(result.data).toHaveProperty("faction");
+      expect(result.data).toHaveProperty("main_stat");
+    });
+
+    it("returns NOT_FOUND error for unknown slug", async () => {
+      const result = await provider.findById("no-such-hero");
+      expect(result.data).toBeNull();
+      expect(result.error).not.toBeNull();
+      expect(result.error!.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("findHeroesUsingEquipment", () => {
+    it("returns heroes that use a known equipment slug", async () => {
+      // First find any hero with equipment slots to get a valid slug
+      const allResult = await provider.findAllWithRelationships();
+      const heroWithSlots = allResult.data!.find(
+        (h) =>
+          h.equipmentSlots.length > 0 &&
+          h.equipmentSlots.some((s) => s.equipment_slug),
+      );
+      if (!heroWithSlots) return; // skip if no equipped heroes in test data
+      const equipSlug = heroWithSlots.equipmentSlots.find(
+        (s) => s.equipment_slug,
+      )!.equipment_slug!;
+
+      const result = await provider.findHeroesUsingEquipment(equipSlug);
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(result.data!.some((h) => h.slug === heroWithSlots.slug)).toBe(
+        true,
+      );
+    });
+
+    it("returns empty array for equipment not used by any hero", async () => {
+      const result = await provider.findHeroesUsingEquipment(
+        "no-such-equipment-xyz",
+      );
+      expect(result.error).toBeNull();
+      expect(result.data).toEqual([]);
+    });
+  });
+
   describe("findAllWithRelationships", () => {
     it("returns all heroes with relationship data", async () => {
       const result = await provider.findAllWithRelationships();

--- a/app/repositories/static/__tests__/StaticHeroProvider.test.ts
+++ b/app/repositories/static/__tests__/StaticHeroProvider.test.ts
@@ -1,0 +1,121 @@
+// ABOUTME: Tests for StaticHeroProvider — verifies hero data served from JSON files.
+// ABOUTME: Covers findAll, findWithAllData, and findAllWithRelationships methods.
+
+import { describe, expect, it } from "vitest";
+
+import { StaticHeroProvider } from "../StaticHeroProvider";
+
+describe("StaticHeroProvider", () => {
+  let provider: StaticHeroProvider;
+
+  provider = new StaticHeroProvider();
+
+  describe("findAll", () => {
+    it("returns a list of heroes without errors", async () => {
+      const result = await provider.findAll();
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it("returns heroes with required fields", async () => {
+      const result = await provider.findAll();
+      const heroes = result.data!;
+      expect(heroes.length).toBeGreaterThan(0);
+      const first = heroes[0];
+      expect(first).toHaveProperty("slug");
+      expect(first).toHaveProperty("name");
+      expect(first).toHaveProperty("class");
+      expect(first).toHaveProperty("faction");
+      expect(first).toHaveProperty("main_stat");
+      expect(first).toHaveProperty("order_rank");
+    });
+
+    it("returns heroes sorted by order_rank", async () => {
+      const result = await provider.findAll();
+      const heroes = result.data!;
+      for (let i = 1; i < heroes.length; i++) {
+        expect(heroes[i].order_rank).toBeGreaterThanOrEqual(
+          heroes[i - 1].order_rank,
+        );
+      }
+    });
+  });
+
+  describe("findWithAllData", () => {
+    it("returns a CompleteHero for a known slug", async () => {
+      const result = await provider.findWithAllData("aidan");
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      const hero = result.data!;
+      expect(hero.slug).toBe("aidan");
+      expect(hero).toHaveProperty("artifacts");
+      expect(hero).toHaveProperty("skins");
+      expect(hero).toHaveProperty("glyphs");
+      expect(hero).toHaveProperty("equipmentSlots");
+    });
+
+    it("returns arrays for relationship fields", async () => {
+      const result = await provider.findWithAllData("aidan");
+      const hero = result.data!;
+      expect(Array.isArray(hero.artifacts)).toBe(true);
+      expect(Array.isArray(hero.skins)).toBe(true);
+      expect(Array.isArray(hero.glyphs)).toBe(true);
+      expect(Array.isArray(hero.equipmentSlots)).toBe(true);
+    });
+
+    it("returns an error for an unknown slug", async () => {
+      const result = await provider.findWithAllData("unknown-hero-slug");
+      expect(result.data).toBeNull();
+      expect(result.error).not.toBeNull();
+      expect(result.error!.code).toBe("NOT_FOUND");
+    });
+
+    it("returns skins with required fields when hero has skins", async () => {
+      const result = await provider.findWithAllData("aidan");
+      const hero = result.data!;
+      expect(hero.skins.length).toBeGreaterThan(0);
+      const skin = hero.skins[0];
+      expect(skin).toHaveProperty("hero_slug");
+      expect(skin).toHaveProperty("name");
+      expect(skin).toHaveProperty("stat_type");
+    });
+
+    it("returns glyphs sorted by position", async () => {
+      const result = await provider.findWithAllData("aidan");
+      const hero = result.data!;
+      expect(hero.glyphs.length).toBeGreaterThan(0);
+      for (let i = 1; i < hero.glyphs.length; i++) {
+        expect(hero.glyphs[i].position).toBeGreaterThan(
+          hero.glyphs[i - 1].position,
+        );
+      }
+    });
+  });
+
+  describe("findAllWithRelationships", () => {
+    it("returns all heroes with relationship data", async () => {
+      const result = await provider.findAllWithRelationships();
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it("returns heroes that have the relationship arrays", async () => {
+      const result = await provider.findAllWithRelationships();
+      const heroes = result.data!;
+      expect(heroes.length).toBeGreaterThan(0);
+      const hero = heroes[0];
+      expect(Array.isArray(hero.artifacts)).toBe(true);
+      expect(Array.isArray(hero.skins)).toBe(true);
+      expect(Array.isArray(hero.glyphs)).toBe(true);
+      expect(Array.isArray(hero.equipmentSlots)).toBe(true);
+    });
+
+    it("returns same count as findAll", async () => {
+      const allResult = await provider.findAll();
+      const withRelResult = await provider.findAllWithRelationships();
+      expect(withRelResult.data!.length).toBe(allResult.data!.length);
+    });
+  });
+});

--- a/app/repositories/static/__tests__/StaticMissionProvider.test.ts
+++ b/app/repositories/static/__tests__/StaticMissionProvider.test.ts
@@ -71,6 +71,85 @@ describe("StaticMissionProvider", () => {
     });
   });
 
+  describe("findById", () => {
+    it("returns a Mission row for a known slug", async () => {
+      const result = await provider.findById("1-1");
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(result.data!.slug).toBe("1-1");
+      expect(result.data!.chapter_id).toBe(1);
+      expect(result.data!.level).toBe(1);
+    });
+
+    it("returns NOT_FOUND error for unknown slug", async () => {
+      const result = await provider.findById("99-99");
+      expect(result.data).toBeNull();
+      expect(result.error).not.toBeNull();
+      expect(result.error!.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("findChapterById", () => {
+    it("returns chapter 1 with the correct title", async () => {
+      const result = await provider.findChapterById(1);
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(result.data!.id).toBe(1);
+      expect(result.data!.title).toBe("Ruled by Fire");
+    });
+
+    it("returns NOT_FOUND error for unknown chapter id", async () => {
+      const result = await provider.findChapterById(9999);
+      expect(result.data).toBeNull();
+      expect(result.error).not.toBeNull();
+      expect(result.error!.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("findByHeroSlug", () => {
+    it("returns missions for a hero that appears as a boss", async () => {
+      // Find a hero slug that exists in mission data by looking at findAll results
+      const allResult = await provider.findAll();
+      const missionWithHero = allResult.data!.find((m) => m.hero_slug !== null);
+      if (!missionWithHero || !missionWithHero.hero_slug) return; // skip if none
+
+      const result = await provider.findByHeroSlug(missionWithHero.hero_slug);
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(result.data!.length).toBeGreaterThan(0);
+      expect(
+        result.data!.every((m) => m.hero_slug === missionWithHero.hero_slug),
+      ).toBe(true);
+    });
+
+    it("returns empty array for a hero slug that is not a boss in any mission", async () => {
+      const result = await provider.findByHeroSlug("no-such-hero-xyz");
+      expect(result.error).toBeNull();
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe("findByCampaignSource", () => {
+    it("returns missions for equipment that has campaign sources", async () => {
+      // apprentices-mantle has campaign_sources: ["1-3", "2-4", ...]
+      const result = await provider.findByCampaignSource("apprentices-mantle");
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(result.data!.length).toBeGreaterThan(0);
+      // All returned missions should be from the campaign_sources list
+      const slugs = result.data!.map((m) => m.slug);
+      expect(slugs).toContain("1-3");
+    });
+
+    it("returns empty array for equipment with no campaign sources", async () => {
+      const result = await provider.findByCampaignSource(
+        "no-such-equipment-xyz",
+      );
+      expect(result.error).toBeNull();
+      expect(result.data).toEqual([]);
+    });
+  });
+
   describe("findAllChapters", () => {
     it("returns a list of chapters without errors", async () => {
       const result = await provider.findAllChapters();

--- a/app/repositories/static/__tests__/StaticMissionProvider.test.ts
+++ b/app/repositories/static/__tests__/StaticMissionProvider.test.ts
@@ -1,0 +1,105 @@
+// ABOUTME: Tests for StaticMissionProvider — verifies mission/chapter data served from JSON files.
+// ABOUTME: Covers findAll and findAllChapters methods.
+
+import { describe, expect, it } from "vitest";
+
+import { StaticMissionProvider } from "../StaticMissionProvider";
+
+describe("StaticMissionProvider", () => {
+  const provider = new StaticMissionProvider();
+
+  describe("findAll", () => {
+    it("returns a list of missions without errors", async () => {
+      const result = await provider.findAll();
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it("returns missions with required DB row fields", async () => {
+      const result = await provider.findAll();
+      const missions = result.data!;
+      expect(missions.length).toBeGreaterThan(0);
+      const first = missions[0];
+      expect(first).toHaveProperty("slug");
+      expect(first).toHaveProperty("name");
+      expect(first).toHaveProperty("chapter_id");
+      expect(first).toHaveProperty("level");
+      expect(first).toHaveProperty("energy_cost");
+      expect(first).toHaveProperty("hero_slug");
+    });
+
+    it("derives chapter_id from slug format 'chapter-level'", async () => {
+      const result = await provider.findAll();
+      const mission = result.data!.find((m) => m.slug === "1-1");
+      expect(mission).toBeDefined();
+      expect(mission!.chapter_id).toBe(1);
+      expect(mission!.level).toBe(1);
+    });
+
+    it("derives chapter_id and level correctly for two-digit chapter", async () => {
+      const result = await provider.findAll();
+      const mission = result.data!.find((m) => m.slug === "10-1");
+      expect(mission).toBeDefined();
+      expect(mission!.chapter_id).toBe(10);
+      expect(mission!.level).toBe(1);
+    });
+
+    it("returns missions sorted by chapter_id then level", async () => {
+      const result = await provider.findAll();
+      const missions = result.data!;
+      for (let i = 1; i < missions.length; i++) {
+        const prev = missions[i - 1];
+        const curr = missions[i];
+        if (prev.chapter_id === curr.chapter_id) {
+          expect(curr.level).toBeGreaterThanOrEqual(prev.level ?? 0);
+        } else {
+          expect(curr.chapter_id).toBeGreaterThanOrEqual(prev.chapter_id);
+        }
+      }
+    });
+
+    it("accepts orderBy options matching live repository behavior", async () => {
+      const result = await provider.findAll({
+        orderBy: [
+          { column: "chapter_id", ascending: true },
+          { column: "level", ascending: true },
+        ],
+      });
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+    });
+  });
+
+  describe("findAllChapters", () => {
+    it("returns a list of chapters without errors", async () => {
+      const result = await provider.findAllChapters();
+      expect(result.error).toBeNull();
+      expect(result.data).not.toBeNull();
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it("returns chapters with id and title fields", async () => {
+      const result = await provider.findAllChapters();
+      const chapters = result.data!;
+      expect(chapters.length).toBeGreaterThan(0);
+      expect(chapters[0]).toHaveProperty("id");
+      expect(chapters[0]).toHaveProperty("title");
+    });
+
+    it("returns chapters sorted by id ascending", async () => {
+      const result = await provider.findAllChapters();
+      const chapters = result.data!;
+      for (let i = 1; i < chapters.length; i++) {
+        expect(chapters[i].id).toBeGreaterThan(chapters[i - 1].id);
+      }
+    });
+
+    it("returns chapter 1 as 'Ruled by Fire'", async () => {
+      const result = await provider.findAllChapters();
+      const chapter1 = result.data!.find((c) => c.id === 1);
+      expect(chapter1).toBeDefined();
+      expect(chapter1!.title).toBe("Ruled by Fire");
+    });
+  });
+});

--- a/app/repositories/static/index.ts
+++ b/app/repositories/static/index.ts
@@ -1,0 +1,6 @@
+// ABOUTME: Barrel export for all static data providers used in static mode.
+// ABOUTME: Re-exports providers for hero, equipment, and mission data from JSON files.
+
+export { StaticHeroProvider } from "./StaticHeroProvider";
+export { StaticEquipmentProvider } from "./StaticEquipmentProvider";
+export { StaticMissionProvider } from "./StaticMissionProvider";

--- a/app/routes/views/account/__tests__/profile.test.tsx
+++ b/app/routes/views/account/__tests__/profile.test.tsx
@@ -48,6 +48,7 @@ describe("AccountProfile Auth Hydration", () => {
         user: null,
         isAuthenticated: false,
         isLoading: true,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -56,7 +57,7 @@ describe("AccountProfile Auth Hydration", () => {
 
       expect(result.getByText("Loading...")).toBeInTheDocument();
       expect(
-        result.getByText("Initializing your account information.")
+        result.getByText("Initializing your account information."),
       ).toBeInTheDocument();
       expect(result.getByTestId("loading-skeleton")).toBeInTheDocument();
 
@@ -76,6 +77,7 @@ describe("AccountProfile Auth Hydration", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -84,7 +86,7 @@ describe("AccountProfile Auth Hydration", () => {
 
       expect(result.getByText("Account Settings")).toBeInTheDocument();
       expect(
-        result.getByText("Manage your account information and preferences.")
+        result.getByText("Manage your account information and preferences."),
       ).toBeInTheDocument();
       expect(result.getByTestId("email")).toHaveValue("user@example.com");
       expect(result.getByTestId("display-name")).toHaveValue("Test User");
@@ -105,6 +107,7 @@ describe("AccountProfile Auth Hydration", () => {
         user: null,
         isAuthenticated: false,
         isLoading: true,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -128,6 +131,7 @@ describe("AccountProfile Auth Hydration", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -138,18 +142,18 @@ describe("AccountProfile Auth Hydration", () => {
       await waitFor(() => {
         expect(result.queryByText("Loading...")).not.toBeInTheDocument();
         expect(
-          result.queryByTestId("loading-skeleton")
+          result.queryByTestId("loading-skeleton"),
         ).not.toBeInTheDocument();
         expect(result.getByText("Account Settings")).toBeInTheDocument();
         expect(result.getByTestId("email")).toHaveValue(
-          "freshly-logged-in@example.com"
+          "freshly-logged-in@example.com",
         );
         expect(result.getByTestId("display-name")).toHaveValue("Fresh User");
       });
 
       // Verify all interactive elements are working
       expect(
-        result.getByRole("button", { name: "Update Display Name" })
+        result.getByRole("button", { name: "Update Display Name" }),
       ).toBeInTheDocument();
       expect(result.getByTestId("display-name")).not.toBeDisabled();
     });
@@ -167,6 +171,7 @@ describe("AccountProfile Auth Hydration", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -192,6 +197,7 @@ describe("AccountProfile Auth Hydration", () => {
         user: null,
         isAuthenticated: false,
         isLoading: true,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -201,7 +207,7 @@ describe("AccountProfile Auth Hydration", () => {
       // User should see loading state (not blank page)
       expect(result.getByText("Loading...")).toBeInTheDocument();
       expect(
-        result.getByText("Initializing your account information.")
+        result.getByText("Initializing your account information."),
       ).toBeInTheDocument();
 
       // The fix: auth completes and user data loads
@@ -216,6 +222,7 @@ describe("AccountProfile Auth Hydration", () => {
         },
         isAuthenticated: true,
         isLoading: false,
+        isStaticMode: false,
         signOut: vi.fn(),
         updateProfile: vi.fn(),
       });
@@ -226,7 +233,7 @@ describe("AccountProfile Auth Hydration", () => {
       await waitFor(() => {
         expect(result.getByText("Account Settings")).toBeInTheDocument();
         expect(result.getByTestId("email")).toHaveValue(
-          "bug-fix-test@example.com"
+          "bug-fix-test@example.com",
         );
         expect(result.getByTestId("display-name")).toHaveValue("Bug Fix User");
       });

--- a/app/routes/views/admin/__tests__/setup.equipment.test.ts
+++ b/app/routes/views/admin/__tests__/setup.equipment.test.ts
@@ -63,30 +63,34 @@ vi.mock("~/lib/supabase/client", () => ({
 
 // Mock the MissionRepository to avoid import issues
 vi.mock("~/repositories/MissionRepository", () => ({
-  MissionRepository: vi.fn().mockImplementation(() => { return {
-    initializeMissionData: vi.fn().mockResolvedValue({
-      data: { chapters: [], missions: [] },
-      error: null,
-    }),
-    purgeMissionDomain: vi.fn().mockResolvedValue({
-      data: { missions: 0, chapters: 0 },
-      error: null,
-    }),
-  }; }),
+  MissionRepository: vi.fn().mockImplementation(function () {
+    return {
+      initializeMissionData: vi.fn().mockResolvedValue({
+        data: { chapters: [], missions: [] },
+        error: null,
+      }),
+      purgeMissionDomain: vi.fn().mockResolvedValue({
+        data: { missions: 0, chapters: 0 },
+        error: null,
+      }),
+    };
+  }),
 }));
 
 // Mock the HeroRepository to avoid import issues
 vi.mock("~/repositories/HeroRepository", () => ({
-  HeroRepository: vi.fn().mockImplementation(() => { return {
-    initializeFromJSON: vi.fn().mockResolvedValue({
-      data: { heroes: [] },
-      error: null,
-    }),
-    purgeHeroDomain: vi.fn().mockResolvedValue({
-      data: { heroes: 0 },
-      error: null,
-    }),
-  }; }),
+  HeroRepository: vi.fn().mockImplementation(function () {
+    return {
+      initializeFromJSON: vi.fn().mockResolvedValue({
+        data: { heroes: [] },
+        error: null,
+      }),
+      purgeHeroDomain: vi.fn().mockResolvedValue({
+        data: { heroes: 0 },
+        error: null,
+      }),
+    };
+  }),
 }));
 
 describe("Admin Setup - Equipment Import", () => {
@@ -161,7 +165,7 @@ describe("Admin Setup - Equipment Import", () => {
 
       vi.spyOn(
         EquipmentRepository.prototype,
-        "initializeFromJSON"
+        "initializeFromJSON",
       ).mockResolvedValue(mockInitResult);
 
       const response = await action({ request: mockRequest } as any);
@@ -177,7 +181,7 @@ describe("Admin Setup - Equipment Import", () => {
 
       // Verify EquipmentRepository was called with correct data
       expect(
-        EquipmentRepository.prototype.initializeFromJSON
+        EquipmentRepository.prototype.initializeFromJSON,
       ).toHaveBeenCalledWith([
         expect.objectContaining({ slug: "test-sword", name: "Test Sword" }),
         expect.objectContaining({
@@ -215,7 +219,7 @@ describe("Admin Setup - Equipment Import", () => {
 
       vi.spyOn(
         EquipmentRepository.prototype,
-        "initializeFromJSON"
+        "initializeFromJSON",
       ).mockResolvedValue({
         data: { equipment: [], stats: [], required_items: [] },
         error: mockError,
@@ -230,10 +234,10 @@ describe("Admin Setup - Equipment Import", () => {
       expect(data.results.equipment.errorDetails).toHaveLength(1);
       expect(data.results.equipment.skippedDetails).toHaveLength(1);
       expect(data.results.equipment.errorDetails[0].record.slug).toBe(
-        "test-sword"
+        "test-sword",
       );
       expect(data.results.equipment.skippedDetails[0].slug).toBe(
-        "test-fragment"
+        "test-fragment",
       );
     });
 
@@ -254,7 +258,7 @@ describe("Admin Setup - Equipment Import", () => {
 
       vi.spyOn(
         EquipmentRepository.prototype,
-        "initializeFromJSON"
+        "initializeFromJSON",
       ).mockResolvedValue({
         data: null,
         error: mockError,
@@ -280,7 +284,7 @@ describe("Admin Setup - Equipment Import", () => {
       // Mock both repositories
       vi.spyOn(
         EquipmentRepository.prototype,
-        "initializeFromJSON"
+        "initializeFromJSON",
       ).mockResolvedValue({
         data: {
           equipment: [
@@ -313,7 +317,7 @@ describe("Admin Setup - Equipment Import", () => {
       expect(data.success).toBe(true);
       expect(data.results.equipment.total).toBe(2);
       expect(
-        EquipmentRepository.prototype.initializeFromJSON
+        EquipmentRepository.prototype.initializeFromJSON,
       ).toHaveBeenCalled();
     });
 
@@ -331,7 +335,7 @@ describe("Admin Setup - Equipment Import", () => {
       // Spy on EquipmentRepository to ensure it's not called
       const equipmentSpy = vi.spyOn(
         EquipmentRepository.prototype,
-        "initializeFromJSON"
+        "initializeFromJSON",
       );
 
       const response = await action({ request: mockRequest } as any);
@@ -353,7 +357,7 @@ describe("Admin Setup - Equipment Import", () => {
 
       vi.spyOn(
         EquipmentRepository.prototype,
-        "initializeFromJSON"
+        "initializeFromJSON",
       ).mockResolvedValue({
         data: { equipment: [], stats: [], required_items: [] },
         error: null,
@@ -383,7 +387,7 @@ describe("Admin Setup - Equipment Import", () => {
       let capturedTransformData: any;
       vi.spyOn(
         EquipmentRepository.prototype,
-        "initializeFromJSON"
+        "initializeFromJSON",
       ).mockImplementation((data) => {
         capturedTransformData = data;
         return Promise.resolve({
@@ -435,7 +439,7 @@ describe("Admin Setup - Equipment Import", () => {
         expect.arrayContaining([
           expect.objectContaining({ slug: "test-sword" }),
           expect.objectContaining({ slug: "test-fragment" }),
-        ])
+        ]),
       );
     });
   });

--- a/app/routes/views/auth/__tests__/static-mode.test.ts
+++ b/app/routes/views/auth/__tests__/static-mode.test.ts
@@ -1,0 +1,119 @@
+// ABOUTME: Tests for auth route loaders and actions in static mode.
+// ABOUTME: Verifies that login, sign-up, and forgot-password redirect/reject in static mode.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { loader as loginLoader, action as loginAction } from "../login";
+import { loader as signUpLoader, action as signUpAction } from "../sign-up";
+import {
+  loader as forgotPasswordLoader,
+  action as forgotPasswordAction,
+} from "../forgot-password";
+
+vi.mock("~/lib/static-mode", () => ({
+  isStaticMode: vi.fn(() => true),
+}));
+
+// Mock createClient to prevent real Supabase calls in non-static branches (unused here)
+vi.mock("~/lib/supabase/client", () => ({
+  createClient: vi.fn(),
+}));
+
+function makeArgs(url: string) {
+  return {
+    request: new Request(url),
+    params: {},
+    context: {},
+    unstable_pattern: "",
+  } as any;
+}
+
+function makePostArgs(url: string) {
+  return {
+    request: new Request(url, { method: "POST" }),
+    params: {},
+    context: {},
+    unstable_pattern: "",
+  } as any;
+}
+
+describe("auth routes in static mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("login loader", () => {
+    it("returns a redirect to / when in static mode", async () => {
+      const response = await loginLoader(
+        makeArgs("http://localhost:3000/login"),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const redirect = response as Response;
+      expect(redirect.status).toBe(302);
+      expect(redirect.headers.get("Location")).toBe("/");
+    });
+  });
+
+  describe("login action", () => {
+    it("returns 403 Response with error when in static mode", async () => {
+      const response = await loginAction(
+        makePostArgs("http://localhost:3000/login"),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const res = response as Response;
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("Not available in read-only mode");
+    });
+  });
+
+  describe("sign-up loader", () => {
+    it("returns a redirect to / when in static mode", async () => {
+      const response = await signUpLoader(
+        makeArgs("http://localhost:3000/sign-up"),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const redirect = response as Response;
+      expect(redirect.status).toBe(302);
+      expect(redirect.headers.get("Location")).toBe("/");
+    });
+  });
+
+  describe("sign-up action", () => {
+    it("returns 403 Response with error when in static mode", async () => {
+      const response = await signUpAction(
+        makePostArgs("http://localhost:3000/sign-up"),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const res = response as Response;
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("Not available in read-only mode");
+    });
+  });
+
+  describe("forgot-password loader", () => {
+    it("returns a redirect to / when in static mode", async () => {
+      const response = await forgotPasswordLoader(
+        makeArgs("http://localhost:3000/forgot-password"),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const redirect = response as Response;
+      expect(redirect.status).toBe(302);
+      expect(redirect.headers.get("Location")).toBe("/");
+    });
+  });
+
+  describe("forgot-password action", () => {
+    it("returns 403 Response with error when in static mode", async () => {
+      const response = await forgotPasswordAction(
+        makePostArgs("http://localhost:3000/forgot-password"),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const res = response as Response;
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("Not available in read-only mode");
+    });
+  });
+});

--- a/app/routes/views/auth/forgot-password.tsx
+++ b/app/routes/views/auth/forgot-password.tsx
@@ -1,5 +1,9 @@
+// ABOUTME: Forgot password page route — sends a password reset email via Supabase.
+// ABOUTME: Redirects to home in static mode where authentication is unavailable.
+
 import {
   type ActionFunctionArgs,
+  type LoaderFunctionArgs,
   Link,
   data,
   redirect,
@@ -17,9 +21,24 @@ import {
 } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { isStaticMode } from "~/lib/static-mode";
 import { createClient } from "~/lib/supabase/client";
 
+export const loader = async (_args: LoaderFunctionArgs) => {
+  if (isStaticMode()) {
+    return redirect("/");
+  }
+  return null;
+};
+
 export const action = async ({ request }: ActionFunctionArgs) => {
+  if (isStaticMode()) {
+    return data({
+      error: "Not available in read-only mode",
+      data: { email: "" },
+    });
+  }
+
   const formData = await request.formData();
   const email = formData.get("email") as string;
 
@@ -37,7 +56,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         error: error instanceof Error ? error.message : "An error occurred",
         data: { email },
       },
-      { headers }
+      { headers },
     );
   }
 

--- a/app/routes/views/auth/forgot-password.tsx
+++ b/app/routes/views/auth/forgot-password.tsx
@@ -33,10 +33,10 @@ export const loader = async (_args: LoaderFunctionArgs) => {
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   if (isStaticMode()) {
-    return data({
-      error: "Not available in read-only mode",
-      data: { email: "" },
-    });
+    return Response.json(
+      { error: "Not available in read-only mode" },
+      { status: 403 },
+    );
   }
 
   const formData = await request.formData();

--- a/app/routes/views/auth/login.tsx
+++ b/app/routes/views/auth/login.tsx
@@ -28,7 +28,10 @@ export const loader = async (_args: LoaderFunctionArgs) => {
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   if (isStaticMode()) {
-    return { error: "Not available in read-only mode" };
+    return Response.json(
+      { error: "Not available in read-only mode" },
+      { status: 403 },
+    );
   }
 
   const { supabase, headers } = createClient(request);

--- a/app/routes/views/auth/login.tsx
+++ b/app/routes/views/auth/login.tsx
@@ -1,4 +1,12 @@
-import { type ActionFunctionArgs, Link, redirect } from "react-router";
+// ABOUTME: Login page route — handles email/password authentication via Supabase.
+// ABOUTME: Redirects to home in static mode where authentication is unavailable.
+
+import {
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  Link,
+  redirect,
+} from "react-router";
 
 import { LoginForm } from "~/components/auth/LoginForm";
 import {
@@ -8,9 +16,21 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
+import { isStaticMode } from "~/lib/static-mode";
 import { createClient } from "~/lib/supabase/client";
 
+export const loader = async (_args: LoaderFunctionArgs) => {
+  if (isStaticMode()) {
+    return redirect("/");
+  }
+  return null;
+};
+
 export const action = async ({ request }: ActionFunctionArgs) => {
+  if (isStaticMode()) {
+    return { error: "Not available in read-only mode" };
+  }
+
   const { supabase, headers } = createClient(request);
 
   const formData = await request.formData();

--- a/app/routes/views/auth/sign-up.tsx
+++ b/app/routes/views/auth/sign-up.tsx
@@ -1,5 +1,9 @@
+// ABOUTME: Sign-up page route — handles new user account creation via Supabase.
+// ABOUTME: Redirects to home in static mode where authentication is unavailable.
+
 import {
   type ActionFunctionArgs,
+  type LoaderFunctionArgs,
   Link,
   redirect,
   useFetcher,
@@ -16,9 +20,21 @@ import {
 } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { isStaticMode } from "~/lib/static-mode";
 import { createClient } from "~/lib/supabase/client";
 
+export const loader = async (_args: LoaderFunctionArgs) => {
+  if (isStaticMode()) {
+    return redirect("/");
+  }
+  return null;
+};
+
 export const action = async ({ request }: ActionFunctionArgs) => {
+  if (isStaticMode()) {
+    return { error: "Not available in read-only mode" };
+  }
+
   const { supabase } = createClient(request);
 
   const url = new URL(request.url);

--- a/app/routes/views/auth/sign-up.tsx
+++ b/app/routes/views/auth/sign-up.tsx
@@ -32,7 +32,10 @@ export const loader = async (_args: LoaderFunctionArgs) => {
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   if (isStaticMode()) {
-    return { error: "Not available in read-only mode" };
+    return Response.json(
+      { error: "Not available in read-only mode" },
+      { status: 403 },
+    );
   }
 
   const { supabase } = createClient(request);

--- a/app/routes/views/equipment/index.tsx
+++ b/app/routes/views/equipment/index.tsx
@@ -11,14 +11,14 @@ import { EquipmentIndexSkeleton } from "~/components/skeletons/EquipmentIndexSke
 import { Button } from "~/components/ui/button";
 import { Card, CardHeader } from "~/components/ui/card";
 import { cn, getEquipmentImageUrl } from "~/lib/utils";
-import { EquipmentRepository } from "~/repositories/EquipmentRepository";
+import { createEquipmentRepository } from "~/repositories/factory";
 import type { Database } from "~/types/supabase";
 
 // Type for equipment from database
 type Equipment = Database["public"]["Tables"]["equipment"]["Row"];
 
 async function loadEquipmentData(request: Request) {
-  const equipmentRepository = new EquipmentRepository(request);
+  const equipmentRepository = createEquipmentRepository(request);
   const equipmentResult = await equipmentRepository.findAll();
 
   if (equipmentResult.error) {

--- a/app/routes/views/equipment/json.tsx
+++ b/app/routes/views/equipment/json.tsx
@@ -4,11 +4,13 @@ import { createReadableStreamFromReadable } from "@react-router/node";
 
 import type { Route } from "./+types/json";
 
-import { EquipmentRepository } from "~/repositories/EquipmentRepository";
+// ABOUTME: Equipment JSON export route — streams all equipment data as a downloadable JSON file.
+// ABOUTME: Uses the repository factory to work in both static and live modes.
 
+import { createEquipmentRepository } from "~/repositories/factory";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const equipmentRepository = new EquipmentRepository(request);
+  const equipmentRepository = createEquipmentRepository(request);
   const equipmentResult = await equipmentRepository.getAllAsJson();
 
   if (equipmentResult.error) {

--- a/app/routes/views/equipment/json.tsx
+++ b/app/routes/views/equipment/json.tsx
@@ -1,11 +1,11 @@
+// ABOUTME: Equipment JSON export route — streams all equipment data as a downloadable JSON file.
+// ABOUTME: Uses the repository factory to work in both static and live modes.
+
 import { Readable } from "node:stream";
 
 import { createReadableStreamFromReadable } from "@react-router/node";
 
 import type { Route } from "./+types/json";
-
-// ABOUTME: Equipment JSON export route — streams all equipment data as a downloadable JSON file.
-// ABOUTME: Uses the repository factory to work in both static and live modes.
 
 import { createEquipmentRepository } from "~/repositories/factory";
 

--- a/app/routes/views/equipment/slug.tsx
+++ b/app/routes/views/equipment/slug.tsx
@@ -26,9 +26,11 @@ import {
   transformCompleteHeroToRecord,
 } from "~/lib/hero-transformations";
 import { generateSlug } from "~/lib/utils";
-import { EquipmentRepository } from "~/repositories/EquipmentRepository";
-import { HeroRepository } from "~/repositories/HeroRepository";
-import { MissionRepository } from "~/repositories/MissionRepository";
+import {
+  createEquipmentRepository,
+  createHeroRepository,
+  createMissionRepository,
+} from "~/repositories/factory";
 import type { Database } from "~/types/supabase";
 
 // Type for mission data from the database
@@ -84,7 +86,7 @@ async function loadBasicEquipmentData(
 ) {
   invariant(params.slug, "Missing equipment slug param");
 
-  const equipmentRepo = new EquipmentRepository(request);
+  const equipmentRepo = createEquipmentRepository(request);
   const equipmentJsonResult = await equipmentRepo.getAllAsJson([params.slug]);
 
   if (
@@ -112,7 +114,7 @@ async function loadDetailedEquipmentData(
 ) {
   invariant(params.slug, "Missing equipment slug param");
 
-  const equipmentRepo = new EquipmentRepository(request);
+  const equipmentRepo = createEquipmentRepository(request);
 
   // Get main equipment details in both formats
   const [equipmentJsonResult, equipmentDbResult] = await Promise.all([
@@ -181,8 +183,8 @@ async function loadDetailedEquipmentData(
     requiredEquipmentRaw = null;
   }
 
-  // Get mission sources using the new repository
-  const missionRepo = new MissionRepository(request);
+  // Get mission sources using the repository factory
+  const missionRepo = createMissionRepository(request);
   const missionSourcesResult = await missionRepo.findByCampaignSource(
     equipment.slug,
   );
@@ -193,7 +195,7 @@ async function loadDetailedEquipmentData(
 
   const missionSources = missionSourcesResult.data || [];
 
-  const heroRepo = new HeroRepository(request);
+  const heroRepo = createHeroRepository(request);
   const heroesUsingItemResult = await heroRepo.findHeroesUsingEquipment(
     equipment.slug,
   );

--- a/app/routes/views/heroes/__tests__/slug.edit.integration.test.ts
+++ b/app/routes/views/heroes/__tests__/slug.edit.integration.test.ts
@@ -31,7 +31,7 @@ describe("Hero Edit Integration", () => {
 
   beforeEach(() => {
     mockRequest = new Request(
-      `http://localhost:3000/heroes/${mockHeroSlug}/edit`
+      `http://localhost:3000/heroes/${mockHeroSlug}/edit`,
     );
 
     mockSupabaseClient = createMockSupabaseClient();
@@ -47,14 +47,22 @@ describe("Hero Edit Integration", () => {
       getAllAsJson: vi.fn(),
     };
 
-    vi.mocked(HeroRepository).mockImplementation(() => { return mockHeroRepo; });
-    vi.mocked(EquipmentRepository).mockImplementation(() => { return mockEquipmentRepo; });
+    vi.mocked(HeroRepository).mockImplementation(function () {
+      return mockHeroRepo;
+    });
+    vi.mocked(EquipmentRepository).mockImplementation(function () {
+      return mockEquipmentRepo;
+    });
 
     // Setup createClient mock to return fresh client each time
-    vi.mocked(supabaseClientModule.createClient).mockImplementation(() => { return {
-      supabase: mockSupabaseClient,
-      headers: undefined,
-    }; });
+    vi.mocked(supabaseClientModule.createClient).mockImplementation(
+      function () {
+        return {
+          supabase: mockSupabaseClient,
+          headers: undefined,
+        };
+      },
+    );
   });
 
   describe("loader", () => {
@@ -95,7 +103,7 @@ describe("Hero Edit Integration", () => {
           request: mockRequest,
           params: { slug: mockHeroSlug },
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
+          unstable_pattern: "",
         } as any);
 
         // Loader returns a Response or throws
@@ -114,8 +122,8 @@ describe("Hero Edit Integration", () => {
           request: mockRequest,
           params: {},
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        } as any)
+          unstable_pattern: "",
+        } as any),
       ).rejects.toThrow();
     });
 
@@ -130,8 +138,8 @@ describe("Hero Edit Integration", () => {
           request: mockRequest,
           params: { slug: mockHeroSlug },
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        } as any)
+          unstable_pattern: "",
+        } as any),
       ).rejects.toThrow();
     });
 
@@ -160,8 +168,8 @@ describe("Hero Edit Integration", () => {
           request: mockRequest,
           params: { slug: mockHeroSlug },
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        } as any)
+          unstable_pattern: "",
+        } as any),
       ).rejects.toThrow();
     });
   });
@@ -190,7 +198,7 @@ describe("Hero Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -205,6 +213,5 @@ describe("Hero Edit Integration", () => {
         expect(result.status).toBe(500);
       }
     });
-
   });
 });

--- a/app/routes/views/heroes/__tests__/static-mode.test.ts
+++ b/app/routes/views/heroes/__tests__/static-mode.test.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Tests for hero route actions in static mode.
+// ABOUTME: Verifies that hero index and slug actions return 403 when in static mode.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { action as heroIndexAction } from "../index";
+import { action as heroSlugAction } from "../slug";
+
+vi.mock("~/lib/static-mode", () => ({
+  isStaticMode: vi.fn(() => true),
+}));
+
+// Mock createClient to prevent real Supabase calls
+vi.mock("~/lib/supabase/client", () => ({
+  createClient: vi.fn(),
+}));
+
+function makePostArgs(url: string) {
+  return {
+    request: new Request(url, { method: "POST" }),
+    params: {},
+    context: {},
+    unstable_pattern: "",
+  } as any;
+}
+
+describe("hero routes in static mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("heroes index action", () => {
+    it("returns 403 Response with error when in static mode", async () => {
+      const response = await heroIndexAction(
+        makePostArgs("http://localhost:3000/heroes"),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const res = response as Response;
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("Not available in read-only mode");
+    });
+  });
+
+  describe("heroes slug action", () => {
+    it("returns 403 Response with error when in static mode", async () => {
+      const response = await heroSlugAction(
+        makePostArgs("http://localhost:3000/heroes/astaroth"),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const res = response as Response;
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("Not available in read-only mode");
+    });
+  });
+});

--- a/app/routes/views/heroes/index.tsx
+++ b/app/routes/views/heroes/index.tsx
@@ -126,7 +126,11 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 };
 
 export const action = async ({ request }: Route.ActionArgs) => {
-  if (isStaticMode()) return { error: "Not available in read-only mode" };
+  if (isStaticMode())
+    return Response.json(
+      { error: "Not available in read-only mode" },
+      { status: 403 },
+    );
 
   const user = await requireAuthenticatedUser(request);
 

--- a/app/routes/views/heroes/index.tsx
+++ b/app/routes/views/heroes/index.tsx
@@ -41,16 +41,19 @@ import {
   type SortOptions,
 } from "~/lib/hero-sorting";
 import { transformCompleteHeroToRecord } from "~/lib/hero-transformations";
-import { EquipmentRepository } from "~/repositories/EquipmentRepository";
-import { HeroRepository } from "~/repositories/HeroRepository";
+import { isStaticMode } from "~/lib/static-mode";
 import { PlayerHeroRepository } from "~/repositories/PlayerHeroRepository";
+import {
+  createHeroRepository,
+  createEquipmentRepository,
+} from "~/repositories/factory";
 import type { Hero } from "~/repositories/types";
 
 async function loadHeroesData(request: Request) {
   const url = new URL(request.url);
   const mode = url.searchParams.get("mode") || "cards";
 
-  const heroRepo = new HeroRepository(request);
+  const heroRepo = createHeroRepository(request);
 
   let heroes: Hero[] | HeroRecord[];
 
@@ -83,7 +86,7 @@ async function loadHeroesData(request: Request) {
   // Only load equipment for tiles mode (cards don't need it)
   let equipment: EquipmentRecord[] = [];
   if (mode === "tiles") {
-    const equipmentRepo = new EquipmentRepository(request);
+    const equipmentRepo = createEquipmentRepository(request);
     const equipmentResult = await equipmentRepo.getAllAsJson();
 
     if (equipmentResult.error) {
@@ -94,15 +97,17 @@ async function loadHeroesData(request: Request) {
       equipmentResult.data?.filter((eq) => eq.type === "equipable") || [];
   }
 
-  // Check user's collection if authenticated
-  const { user } = await getAuthenticatedUser(request);
+  // Check user's collection if authenticated (skipped in static mode)
   let userCollection: string[] = [];
 
-  if (user) {
-    const playerHeroRepo = new PlayerHeroRepository(request);
-    const collectionResult = await playerHeroRepo.findByUserId(user.id);
-    if (!collectionResult.error && collectionResult.data) {
-      userCollection = collectionResult.data.map((ph) => ph.hero_slug);
+  if (!isStaticMode()) {
+    const { user } = await getAuthenticatedUser(request);
+    if (user) {
+      const playerHeroRepo = new PlayerHeroRepository(request);
+      const collectionResult = await playerHeroRepo.findByUserId(user.id);
+      if (!collectionResult.error && collectionResult.data) {
+        userCollection = collectionResult.data.map((ph) => ph.hero_slug);
+      }
     }
   }
 
@@ -121,6 +126,8 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 };
 
 export const action = async ({ request }: Route.ActionArgs) => {
+  if (isStaticMode()) return { error: "Not available in read-only mode" };
+
   const user = await requireAuthenticatedUser(request);
 
   const formData = await request.formData();

--- a/app/routes/views/heroes/index.tsx
+++ b/app/routes/views/heroes/index.tsx
@@ -2,6 +2,7 @@ import { Suspense, useState, useMemo } from "react";
 
 import { ToggleGroup } from "@radix-ui/react-toggle-group";
 import { LayoutGridIcon, LayoutListIcon } from "lucide-react";
+import log from "loglevel";
 import { Await, Link, useFetcher, useNavigate } from "react-router";
 
 import type { Route } from "./+types/index";
@@ -105,7 +106,12 @@ async function loadHeroesData(request: Request) {
     if (user) {
       const playerHeroRepo = new PlayerHeroRepository(request);
       const collectionResult = await playerHeroRepo.findByUserId(user.id);
-      if (!collectionResult.error && collectionResult.data) {
+      if (collectionResult.error) {
+        log.warn(
+          "Failed to load user collection:",
+          collectionResult.error.message,
+        );
+      } else if (collectionResult.data) {
         userCollection = collectionResult.data.map((ph) => ph.hero_slug);
       }
     }

--- a/app/routes/views/heroes/json.tsx
+++ b/app/routes/views/heroes/json.tsx
@@ -1,11 +1,11 @@
+// ABOUTME: Hero JSON export route — streams all hero data as a downloadable JSON file.
+// ABOUTME: Uses the repository factory to work in both static and live modes.
+
 import { Readable } from "node:stream";
 
 import { createReadableStreamFromReadable } from "@react-router/node";
 
 import type { Route } from "./+types/json";
-
-// ABOUTME: Hero JSON export route — streams all hero data as a downloadable JSON file.
-// ABOUTME: Uses the repository factory to work in both static and live modes.
 
 import {
   transformCompleteHeroToRecord,

--- a/app/routes/views/heroes/json.tsx
+++ b/app/routes/views/heroes/json.tsx
@@ -4,17 +4,19 @@ import { createReadableStreamFromReadable } from "@react-router/node";
 
 import type { Route } from "./+types/json";
 
+// ABOUTME: Hero JSON export route — streams all hero data as a downloadable JSON file.
+// ABOUTME: Uses the repository factory to work in both static and live modes.
+
 import {
   transformCompleteHeroToRecord,
   transformBasicHeroToRecord,
   sortHeroRecords,
   createHeroesJsonString,
 } from "~/lib/hero-transformations";
-import { HeroRepository } from "~/repositories/HeroRepository";
-
+import { createHeroRepository } from "~/repositories/factory";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const heroRepo = new HeroRepository(request);
+  const heroRepo = createHeroRepository(request);
   const heroesResult = await heroRepo.findAll();
 
   if (heroesResult.error) {
@@ -31,7 +33,7 @@ export async function loader({ request }: Route.LoaderArgs) {
           }
           // Fallback to basic hero if complete data is not available
           return transformBasicHeroToRecord(hero);
-        })
+        }),
       )
     : [];
 

--- a/app/routes/views/heroes/slug.json.tsx
+++ b/app/routes/views/heroes/slug.json.tsx
@@ -1,10 +1,10 @@
+// ABOUTME: Hero JSON detail route — displays all data for a single hero as formatted JSON.
+// ABOUTME: Uses repository factories to support both static and live data sources.
+
 import { type UIMatch } from "react-router";
 import invariant from "tiny-invariant";
 
 import type { Route } from "./+types/slug.json";
-
-// ABOUTME: Hero JSON detail route — displays all data for a single hero as formatted JSON.
-// ABOUTME: Uses repository factories to support both static and live data sources.
 
 import {
   transformCompleteHeroToRecord,

--- a/app/routes/views/heroes/slug.json.tsx
+++ b/app/routes/views/heroes/slug.json.tsx
@@ -3,14 +3,19 @@ import invariant from "tiny-invariant";
 
 import type { Route } from "./+types/slug.json";
 
+// ABOUTME: Hero JSON detail route — displays all data for a single hero as formatted JSON.
+// ABOUTME: Uses repository factories to support both static and live data sources.
+
 import {
   transformCompleteHeroToRecord,
   transformBasicHeroToRecord,
   sortHeroRecords,
 } from "~/lib/hero-transformations";
-import { EquipmentRepository } from "~/repositories/EquipmentRepository";
-import { HeroRepository } from "~/repositories/HeroRepository";
-import { MissionRepository } from "~/repositories/MissionRepository";
+import {
+  createHeroRepository,
+  createEquipmentRepository,
+  createMissionRepository,
+} from "~/repositories/factory";
 
 export const meta = ({ loaderData }: Route.MetaArgs) => {
   return [
@@ -36,7 +41,7 @@ export const handle = {
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   invariant(params.slug, "Missing hero slug param");
 
-  const heroRepo = new HeroRepository(request);
+  const heroRepo = createHeroRepository(request);
   const heroResult = await heroRepo.findWithAllData(params.slug);
 
   if (heroResult.error || !heroResult.data) {
@@ -48,10 +53,8 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
 
   const hero = transformCompleteHeroToRecord(heroResult.data);
 
-  const missionRepo = new MissionRepository(request);
-  const campaignSourcesResult = await missionRepo.findByHeroSlug(
-    params.slug
-  );
+  const missionRepo = createMissionRepository(request);
+  const campaignSourcesResult = await missionRepo.findByHeroSlug(params.slug);
 
   if (campaignSourcesResult.error) {
     throw new Response("Failed to load campaign sources", { status: 500 });
@@ -64,7 +67,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
       equipmentSlugs.push(...tier[1]);
     }
   }
-  const equipmentRepo = new EquipmentRepository(request);
+  const equipmentRepo = createEquipmentRepository(request);
   const equipmentUsedResult = await equipmentRepo.findAll();
 
   if (equipmentUsedResult.error) {

--- a/app/routes/views/heroes/slug.tsx
+++ b/app/routes/views/heroes/slug.tsx
@@ -35,10 +35,13 @@ import {
   transformBasicHeroToRecord,
   transformCompleteHeroToRecord,
 } from "~/lib/hero-transformations";
-import { EquipmentRepository } from "~/repositories/EquipmentRepository";
-import { HeroRepository } from "~/repositories/HeroRepository";
-import { MissionRepository } from "~/repositories/MissionRepository";
+import { isStaticMode } from "~/lib/static-mode";
 import { PlayerHeroRepository } from "~/repositories/PlayerHeroRepository";
+import {
+  createHeroRepository,
+  createEquipmentRepository,
+  createMissionRepository,
+} from "~/repositories/factory";
 
 export const meta = ({ loaderData }: Route.MetaArgs) => {
   const heroName = loaderData?.basicHero?.name || "Hero Details";
@@ -57,7 +60,7 @@ export const handle = {
 async function loadBasicHeroData(params: { slug: string }, request: Request) {
   invariant(params.slug, "Missing hero slug param");
 
-  const heroRepo = new HeroRepository(request);
+  const heroRepo = createHeroRepository(request);
   const heroResult = await heroRepo.findById(params.slug);
 
   if (heroResult.error || !heroResult.data) {
@@ -81,7 +84,7 @@ async function loadDetailedHeroData(
 ) {
   invariant(params.slug, "Missing hero slug param");
 
-  const heroRepo = new HeroRepository(request);
+  const heroRepo = createHeroRepository(request);
   const heroResult = await heroRepo.findWithAllData(params.slug);
 
   if (heroResult.error || !heroResult.data) {
@@ -93,25 +96,27 @@ async function loadDetailedHeroData(
 
   const hero = transformCompleteHeroToRecord(heroResult.data);
 
-  const missionRepo = new MissionRepository(request);
+  const missionRepo = createMissionRepository(request);
   const campaignSourcesResult = await missionRepo.findByHeroSlug(params.slug);
 
   if (campaignSourcesResult.error) {
     throw new Response("Failed to load campaign sources", { status: 500 });
   }
 
-  // Check if hero is in user's collection
-  const { user } = await getAuthenticatedUser(request);
+  // Check if hero is in user's collection (skipped in static mode)
   let isInCollection = false;
 
-  if (user) {
-    const playerHeroRepo = new PlayerHeroRepository(request);
-    const collectionResult = await playerHeroRepo.isHeroInCollection(
-      user.id,
-      params.slug,
-    );
-    if (!collectionResult.error && collectionResult.data) {
-      isInCollection = collectionResult.data;
+  if (!isStaticMode()) {
+    const { user } = await getAuthenticatedUser(request);
+    if (user) {
+      const playerHeroRepo = new PlayerHeroRepository(request);
+      const collectionResult = await playerHeroRepo.isHeroInCollection(
+        user.id,
+        params.slug,
+      );
+      if (!collectionResult.error && collectionResult.data) {
+        isInCollection = collectionResult.data;
+      }
     }
   }
 
@@ -135,7 +140,7 @@ async function loadDetailedHeroData(
     }
   }
 
-  const equipmentRepo = new EquipmentRepository(request);
+  const equipmentRepo = createEquipmentRepository(request);
   const equipmentUsedResult = await equipmentRepo.getAllAsJson();
 
   if (equipmentUsedResult.error) {
@@ -194,6 +199,8 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
 };
 
 export const action = async ({ request }: Route.ActionArgs) => {
+  if (isStaticMode()) return { error: "Not available in read-only mode" };
+
   const user = await requireAuthenticatedUser(request);
 
   const formData = await request.formData();

--- a/app/routes/views/heroes/slug.tsx
+++ b/app/routes/views/heroes/slug.tsx
@@ -199,7 +199,11 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
 };
 
 export const action = async ({ request }: Route.ActionArgs) => {
-  if (isStaticMode()) return { error: "Not available in read-only mode" };
+  if (isStaticMode())
+    return Response.json(
+      { error: "Not available in read-only mode" },
+      { status: 403 },
+    );
 
   const user = await requireAuthenticatedUser(request);
 

--- a/app/routes/views/heroes/slug.tsx
+++ b/app/routes/views/heroes/slug.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useEffect } from "react";
 
 import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
+import log from "loglevel";
 import {
   Await,
   Link,
@@ -114,7 +115,12 @@ async function loadDetailedHeroData(
         user.id,
         params.slug,
       );
-      if (!collectionResult.error && collectionResult.data) {
+      if (collectionResult.error) {
+        log.warn(
+          "Failed to check hero collection status:",
+          collectionResult.error.message,
+        );
+      } else if (collectionResult.data) {
         isInCollection = collectionResult.data;
       }
     }

--- a/app/routes/views/missions/index.tsx
+++ b/app/routes/views/missions/index.tsx
@@ -18,13 +18,11 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 import { cn, getHeroImageUrl } from "~/lib/utils";
-import {
-  MissionRepository,
-  type Mission,
-} from "~/repositories/MissionRepository";
+import { type Mission } from "~/repositories/MissionRepository";
+import { createMissionRepository } from "~/repositories/factory";
 
 async function loadMissionsData(request: Request) {
-  const missionRepo = new MissionRepository(request);
+  const missionRepo = createMissionRepository(request);
   const missionsResult = await missionRepo.findAll({
     orderBy: [
       { column: "chapter_id", ascending: true },
@@ -52,22 +50,26 @@ async function loadMissionsData(request: Request) {
     new Set(
       missions
         .map((m) => m.hero_slug)
-        .filter((slug): slug is string => slug !== null)
-    )
+        .filter((slug): slug is string => slug !== null),
+    ),
   ).sort();
 
   // Group missions by chapter for organized display
-  const missionsByChapter = missions.reduce((acc, mission) => {
-    if (!acc[mission.chapter_id]) {
-      acc[mission.chapter_id] = {
-        title:
-          chapterMap.get(mission.chapter_id) || `Chapter ${mission.chapter_id}`,
-        missions: [],
-      };
-    }
-    acc[mission.chapter_id].missions.push(mission);
-    return acc;
-  }, {} as Record<number, { title: string; missions: Mission[] }>);
+  const missionsByChapter = missions.reduce(
+    (acc, mission) => {
+      if (!acc[mission.chapter_id]) {
+        acc[mission.chapter_id] = {
+          title:
+            chapterMap.get(mission.chapter_id) ||
+            `Chapter ${mission.chapter_id}`,
+          missions: [],
+        };
+      }
+      acc[mission.chapter_id].missions.push(mission);
+      return acc;
+    },
+    {} as Record<number, { title: string; missions: Mission[] }>,
+  );
 
   return { missionsByChapter, uniqueBosses };
 }
@@ -104,27 +106,31 @@ function MissionsContent({
   const filteredMissionsByChapter = useMemo(() => {
     const lowercaseQuery = searchQuery.toLowerCase();
 
-    return Object.entries(missionsByChapter).reduce((acc, [chapter, data]) => {
-      const chapterNum = Number(chapter);
-      const filteredMissions = data.missions.filter((mission) => {
-        const matchesSearch =
-          mission.slug.toLowerCase().includes(lowercaseQuery) ||
-          mission.name.toLowerCase().includes(lowercaseQuery);
+    return Object.entries(missionsByChapter).reduce(
+      (acc, [chapter, data]) => {
+        const chapterNum = Number(chapter);
+        const filteredMissions = data.missions.filter((mission) => {
+          const matchesSearch =
+            mission.slug.toLowerCase().includes(lowercaseQuery) ||
+            mission.name.toLowerCase().includes(lowercaseQuery);
 
-        const matchesBoss = !selectedBoss || mission.hero_slug === selectedBoss;
+          const matchesBoss =
+            !selectedBoss || mission.hero_slug === selectedBoss;
 
-        return matchesSearch && matchesBoss;
-      });
+          return matchesSearch && matchesBoss;
+        });
 
-      if (filteredMissions.length > 0) {
-        acc[chapterNum] = {
-          title: data.title,
-          missions: filteredMissions,
-        };
-      }
+        if (filteredMissions.length > 0) {
+          acc[chapterNum] = {
+            title: data.title,
+            missions: filteredMissions,
+          };
+        }
 
-      return acc;
-    }, {} as Record<number, { title: string; missions: Mission[] }>);
+        return acc;
+      },
+      {} as Record<number, { title: string; missions: Mission[] }>,
+    );
   }, [missionsByChapter, searchQuery, selectedBoss]);
 
   return (
@@ -200,7 +206,7 @@ function MissionsContent({
                             "text-2xl font-bold",
                             mission.hero_slug
                               ? "text-foreground"
-                              : "text-muted-foreground"
+                              : "text-muted-foreground",
                           )}
                         >
                           {mission.slug}
@@ -210,7 +216,7 @@ function MissionsContent({
                         className={cn(
                           cardVariants({
                             variant: mission.hero_slug ? "boss" : "default",
-                          })
+                          }),
                         )}
                       >
                         <CardTitle className="text-sm truncate">
@@ -227,7 +233,7 @@ function MissionsContent({
                 ))}
               </div>
             </div>
-          )
+          ),
         )
       ) : (
         <div className="text-center text-muted-foreground py-8">

--- a/app/routes/views/missions/json.tsx
+++ b/app/routes/views/missions/json.tsx
@@ -4,11 +4,13 @@ import { createReadableStreamFromReadable } from "@react-router/node";
 
 import type { Route } from "./+types/json";
 
-import { MissionRepository } from "~/repositories/MissionRepository";
+// ABOUTME: Missions JSON export route — streams all mission and chapter data as a downloadable JSON file.
+// ABOUTME: Uses the repository factory to work in both static and live modes.
 
+import { createMissionRepository } from "~/repositories/factory";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const missionRepo = new MissionRepository(request);
+  const missionRepo = createMissionRepository(request);
 
   // Get missions with proper sorting
   const missionsResult = await missionRepo.findAll({

--- a/app/routes/views/missions/json.tsx
+++ b/app/routes/views/missions/json.tsx
@@ -1,11 +1,11 @@
+// ABOUTME: Missions JSON export route — streams all mission and chapter data as a downloadable JSON file.
+// ABOUTME: Uses the repository factory to work in both static and live modes.
+
 import { Readable } from "node:stream";
 
 import { createReadableStreamFromReadable } from "@react-router/node";
 
 import type { Route } from "./+types/json";
-
-// ABOUTME: Missions JSON export route — streams all mission and chapter data as a downloadable JSON file.
-// ABOUTME: Uses the repository factory to work in both static and live modes.
 
 import { createMissionRepository } from "~/repositories/factory";
 

--- a/app/routes/views/missions/slug.tsx
+++ b/app/routes/views/missions/slug.tsx
@@ -10,8 +10,10 @@ import EquipmentImage from "~/components/EquipmentImage";
 import { buttonVariants } from "~/components/ui/button";
 import { type EquipmentRecord } from "~/data/equipment.zod";
 import { generateSlug, getHeroImageUrl } from "~/lib/utils";
-import { EquipmentRepository } from "~/repositories/EquipmentRepository";
-import { MissionRepository } from "~/repositories/MissionRepository";
+import {
+  createEquipmentRepository,
+  createMissionRepository,
+} from "~/repositories/factory";
 
 export const meta = ({ data }: Route.MetaArgs) => {
   if (!data) {
@@ -40,7 +42,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     throw new Response("Missing slug parameter", { status: 400 });
   }
 
-  const missionRepo = new MissionRepository(request);
+  const missionRepo = createMissionRepository(request);
 
   // Find the mission
   const [missionsResult, missionResult] = await Promise.all([
@@ -69,7 +71,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     chapterResult.data?.title || `Chapter ${mission.chapter_id}`;
 
   // Get equipment that can be found in this mission
-  const equipmentRepo = new EquipmentRepository(request);
+  const equipmentRepo = createEquipmentRepository(request);
   const allEquipmentResult = await equipmentRepo.getAllAsJson();
 
   if (allEquipmentResult.error) {

--- a/app/routes/views/player/__tests__/activity.integration.test.ts
+++ b/app/routes/views/player/__tests__/activity.integration.test.ts
@@ -36,9 +36,9 @@ describe("Player Activity Integration", () => {
       findEventsByUser: vi.fn(),
     };
 
-    vi.mocked(PlayerEventRepository).mockImplementation(
-      () => { return mockPlayerEventRepo; }
-    );
+    vi.mocked(PlayerEventRepository).mockImplementation(function () {
+      return mockPlayerEventRepo;
+    });
 
     // Mock auth utilities
     vi.mocked(getAuthenticatedUser).mockResolvedValue({
@@ -100,10 +100,10 @@ describe("Player Activity Integration", () => {
       expect(mockPlayerEventRepo.findRecentEvents).toHaveBeenCalledWith(
         "user1",
         10,
-        0
+        0,
       );
       expect(mockPlayerEventRepo.findEventsByUser).toHaveBeenCalledWith(
-        "user1"
+        "user1",
       );
     });
 
@@ -189,10 +189,10 @@ describe("Player Activity Integration", () => {
       expect(mockPlayerEventRepo.findRecentEvents).toHaveBeenCalledWith(
         "user1",
         10,
-        0
+        0,
       );
       expect(mockPlayerEventRepo.findEventsByUser).toHaveBeenCalledWith(
-        "user1"
+        "user1",
       );
     });
 
@@ -231,10 +231,10 @@ describe("Player Activity Integration", () => {
       expect(mockPlayerEventRepo.findRecentEvents).toHaveBeenCalledWith(
         "user2",
         10,
-        0
+        0,
       );
       expect(mockPlayerEventRepo.findEventsByUser).toHaveBeenCalledWith(
-        "user2"
+        "user2",
       );
     });
   });

--- a/app/routes/views/player/__tests__/roster.integration.test.ts
+++ b/app/routes/views/player/__tests__/roster.integration.test.ts
@@ -50,10 +50,12 @@ describe("Player Roster Integration", () => {
       addAllHeroesToCollection: vi.fn(),
     };
 
-    vi.mocked(HeroRepository).mockImplementation(() => { return mockHeroRepo; });
-    vi.mocked(PlayerHeroRepository).mockImplementation(
-      () => { return mockPlayerHeroRepo; }
-    );
+    vi.mocked(HeroRepository).mockImplementation(function () {
+      return mockHeroRepo;
+    });
+    vi.mocked(PlayerHeroRepository).mockImplementation(function () {
+      return mockPlayerHeroRepo;
+    });
 
     // Mock auth utilities
     vi.mocked(getAuthenticatedUser).mockResolvedValue({
@@ -178,8 +180,8 @@ describe("Player Roster Integration", () => {
           request: mockRequest,
           params: {},
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
 
@@ -256,7 +258,7 @@ describe("Player Roster Integration", () => {
           hero_slug: "astaroth",
           stars: 1,
           equipment_level: 1,
-        }
+        },
       );
     });
 
@@ -315,7 +317,7 @@ describe("Player Roster Integration", () => {
       expect(mockPlayerHeroRepo.updateHeroProgress).toHaveBeenCalledWith(
         "user1",
         "astaroth",
-        { stars: 5 }
+        { stars: 5 },
       );
     });
   });
@@ -349,7 +351,7 @@ describe("Player Roster Integration", () => {
       expect(mockPlayerHeroRepo.updateHeroProgress).toHaveBeenCalledWith(
         "user1",
         "astaroth",
-        { equipment_level: 15 }
+        { equipment_level: 15 },
       );
     });
   });
@@ -381,7 +383,7 @@ describe("Player Roster Integration", () => {
       expect(result.message).toBe("Hero removed from collection");
       expect(mockPlayerHeroRepo.removeFromCollection).toHaveBeenCalledWith(
         "user1",
-        "astaroth"
+        "astaroth",
       );
     });
   });
@@ -390,7 +392,7 @@ describe("Player Roster Integration", () => {
     it("should return error for unauthenticated user", async () => {
       // Mock requireAuthenticatedUser to throw for this test
       vi.mocked(requireAuthenticatedUser).mockRejectedValue(
-        new Response("Authentication required", { status: 401 })
+        new Response("Authentication required", { status: 401 }),
       );
 
       const formData = new FormData();
@@ -407,8 +409,8 @@ describe("Player Roster Integration", () => {
           request: mockRequest,
           params: {},
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
 
@@ -448,7 +450,16 @@ describe("Player Roster Integration", () => {
           addedCount: 8,
           skippedCount: 2,
           errorCount: 0,
-          addedHeroes: ["galahad", "keira", "maya", "qing-mao", "jet", "thea", "aurora", "dante"],
+          addedHeroes: [
+            "galahad",
+            "keira",
+            "maya",
+            "qing-mao",
+            "jet",
+            "thea",
+            "aurora",
+            "dante",
+          ],
           skippedHeroes: ["astaroth", "celeste"],
           errors: [],
         },
@@ -465,12 +476,17 @@ describe("Player Roster Integration", () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.message).toBe("Successfully added 8 heroes to your collection!");
+      expect(result.message).toBe(
+        "Successfully added 8 heroes to your collection!",
+      );
       expect(result.data).toEqual(mockResult.data);
-      expect(mockPlayerHeroRepo.addAllHeroesToCollection).toHaveBeenCalledWith("user1", {
-        batchSize: 50,
-        parallelism: 5,
-      });
+      expect(mockPlayerHeroRepo.addAllHeroesToCollection).toHaveBeenCalledWith(
+        "user1",
+        {
+          batchSize: 50,
+          parallelism: 5,
+        },
+      );
     });
 
     it("should handle case when all heroes already in collection", async () => {
@@ -550,7 +566,9 @@ describe("Player Roster Integration", () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.message).toBe("Added 3 heroes to your collection. 1 heroes had errors.");
+      expect(result.message).toBe(
+        "Added 3 heroes to your collection. 1 heroes had errors.",
+      );
       expect(result.data).toEqual(mockResult.data);
     });
 
@@ -567,7 +585,8 @@ describe("Player Roster Integration", () => {
         data: null,
         error: {
           code: "FETCH_HEROES_FAILED",
-          message: "Failed to fetch available heroes: Database connection failed",
+          message:
+            "Failed to fetch available heroes: Database connection failed",
         },
       };
 
@@ -580,7 +599,9 @@ describe("Player Roster Integration", () => {
         unstable_pattern: "",
       });
 
-      expect(result.error).toBe("Failed to fetch available heroes: Database connection failed");
+      expect(result.error).toBe(
+        "Failed to fetch available heroes: Database connection failed",
+      );
       expect(result.code).toBe("FETCH_HEROES_FAILED");
     });
 

--- a/app/routes/views/player/__tests__/teams.edit.integration.test.ts
+++ b/app/routes/views/player/__tests__/teams.edit.integration.test.ts
@@ -39,7 +39,7 @@ describe("Player Teams Edit Integration", () => {
 
   beforeEach(() => {
     mockRequest = new Request(
-      `http://localhost:3000/player/teams/${mockSlug}/edit`
+      `http://localhost:3000/player/teams/${mockSlug}/edit`,
     );
 
     mockTeamRepo = {
@@ -55,10 +55,12 @@ describe("Player Teams Edit Integration", () => {
       findWithHeroDetails: vi.fn(),
     };
 
-    vi.mocked(PlayerTeamRepository).mockImplementation(() => { return mockTeamRepo; });
-    vi.mocked(PlayerHeroRepository).mockImplementation(
-      () => { return mockPlayerHeroRepo; }
-    );
+    vi.mocked(PlayerTeamRepository).mockImplementation(function () {
+      return mockTeamRepo;
+    });
+    vi.mocked(PlayerHeroRepository).mockImplementation(function () {
+      return mockPlayerHeroRepo;
+    });
 
     // Mock auth utilities
     vi.mocked(getAuthenticatedUser).mockResolvedValue({
@@ -170,10 +172,10 @@ describe("Player Teams Edit Integration", () => {
       expect(result.userHeroes).toHaveLength(2);
       expect(mockTeamRepo.findTeamBySlug).toHaveBeenCalledWith(
         mockSlug,
-        "user1"
+        "user1",
       );
       expect(mockPlayerHeroRepo.findWithHeroDetails).toHaveBeenCalledWith(
-        "user1"
+        "user1",
       );
     });
 
@@ -188,8 +190,8 @@ describe("Player Teams Edit Integration", () => {
           request: mockRequest,
           params: { slug: mockSlug },
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
 
@@ -199,8 +201,8 @@ describe("Player Teams Edit Integration", () => {
           request: mockRequest,
           params: {},
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        } as any)
+          unstable_pattern: "",
+        } as any),
       ).rejects.toThrow(Response);
     });
 
@@ -219,8 +221,8 @@ describe("Player Teams Edit Integration", () => {
           request: mockRequest,
           params: { slug: mockSlug },
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
 
@@ -247,8 +249,8 @@ describe("Player Teams Edit Integration", () => {
           request: mockRequest,
           params: { slug: mockSlug },
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
   });
@@ -284,7 +286,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -296,7 +298,7 @@ describe("Player Teams Edit Integration", () => {
 
       expect(result.success).toBe(true);
       expect(result.message).toBe(
-        'Team "Updated Arena Team" updated successfully'
+        'Team "Updated Arena Team" updated successfully',
       );
       expect(mockTeamRepo.updateTeam).toHaveBeenCalledWith(
         mockTeamId,
@@ -304,7 +306,7 @@ describe("Player Teams Edit Integration", () => {
         {
           name: "Updated Arena Team",
           description: "Updated description",
-        }
+        },
       );
     });
 
@@ -338,7 +340,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -355,7 +357,7 @@ describe("Player Teams Edit Integration", () => {
         {
           name: undefined,
           description: undefined,
-        }
+        },
       );
     });
 
@@ -386,7 +388,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -425,7 +427,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -440,7 +442,7 @@ describe("Player Teams Edit Integration", () => {
       expect(mockTeamRepo.addHeroToTeam).toHaveBeenCalledWith(
         mockTeamId,
         "user1",
-        { hero_slug: "aurora" }
+        { hero_slug: "aurora" },
       );
     });
 
@@ -465,7 +467,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -505,7 +507,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -547,7 +549,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -562,7 +564,7 @@ describe("Player Teams Edit Integration", () => {
       expect(mockTeamRepo.removeHeroFromTeam).toHaveBeenCalledWith(
         mockTeamId,
         "user1",
-        "astaroth"
+        "astaroth",
       );
     });
 
@@ -587,7 +589,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -627,7 +629,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -663,7 +665,7 @@ describe("Player Teams Edit Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({

--- a/app/routes/views/player/__tests__/teams.integration.test.ts
+++ b/app/routes/views/player/__tests__/teams.integration.test.ts
@@ -41,7 +41,9 @@ describe("Player Teams Integration", () => {
       deleteTeam: vi.fn(),
     };
 
-    vi.mocked(PlayerTeamRepository).mockImplementation(() => { return mockTeamRepo; });
+    vi.mocked(PlayerTeamRepository).mockImplementation(function () {
+      return mockTeamRepo;
+    });
 
     // Mock auth utilities
     vi.mocked(getAuthenticatedUser).mockResolvedValue({
@@ -118,8 +120,8 @@ describe("Player Teams Integration", () => {
           request: mockRequest,
           params: {},
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
 
@@ -134,8 +136,8 @@ describe("Player Teams Integration", () => {
           request: mockRequest,
           params: {},
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
 
@@ -285,7 +287,7 @@ describe("Player Teams Integration", () => {
       expect(result.message).toBe("Team deleted successfully");
       expect(mockTeamRepo.deleteTeam).toHaveBeenCalledWith(
         "team-to-delete",
-        "user1"
+        "user1",
       );
     });
 

--- a/app/routes/views/player/__tests__/teams.new.integration.test.ts
+++ b/app/routes/views/player/__tests__/teams.new.integration.test.ts
@@ -48,10 +48,12 @@ describe("Player Teams New Integration", () => {
       findWithHeroDetails: vi.fn(),
     };
 
-    vi.mocked(PlayerTeamRepository).mockImplementation(() => { return mockTeamRepo; });
-    vi.mocked(PlayerHeroRepository).mockImplementation(
-      () => { return mockPlayerHeroRepo; }
-    );
+    vi.mocked(PlayerTeamRepository).mockImplementation(function () {
+      return mockTeamRepo;
+    });
+    vi.mocked(PlayerHeroRepository).mockImplementation(function () {
+      return mockPlayerHeroRepo;
+    });
 
     // Mock auth utilities
     vi.mocked(getAuthenticatedUser).mockResolvedValue({
@@ -133,7 +135,7 @@ describe("Player Teams New Integration", () => {
       expect(result.userHeroes[0].hero_slug).toBe("astaroth");
       expect(result.userHeroes[1].hero_slug).toBe("aurora");
       expect(mockPlayerHeroRepo.findWithHeroDetails).toHaveBeenCalledWith(
-        "user1"
+        "user1",
       );
     });
 
@@ -148,8 +150,8 @@ describe("Player Teams New Integration", () => {
           request: mockRequest,
           params: {},
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
 
@@ -164,8 +166,8 @@ describe("Player Teams New Integration", () => {
           request: mockRequest,
           params: {},
           context: { VALUE_FROM_NETLIFY: "test" },
-        unstable_pattern: "",
-        })
+          unstable_pattern: "",
+        }),
       ).rejects.toThrow(Response);
     });
 
@@ -216,7 +218,7 @@ describe("Player Teams New Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -241,19 +243,19 @@ describe("Player Teams New Integration", () => {
         1,
         "new-team-id",
         "user1",
-        { hero_slug: "astaroth" }
+        { hero_slug: "astaroth" },
       );
       expect(mockTeamRepo.addHeroToTeam).toHaveBeenNthCalledWith(
         2,
         "new-team-id",
         "user1",
-        { hero_slug: "aurora" }
+        { hero_slug: "aurora" },
       );
       expect(mockTeamRepo.addHeroToTeam).toHaveBeenNthCalledWith(
         3,
         "new-team-id",
         "user1",
-        { hero_slug: "celeste" }
+        { hero_slug: "celeste" },
       );
     });
 
@@ -282,7 +284,7 @@ describe("Player Teams New Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -325,7 +327,7 @@ describe("Player Teams New Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -357,7 +359,7 @@ describe("Player Teams New Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -403,7 +405,7 @@ describe("Player Teams New Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({
@@ -414,11 +416,11 @@ describe("Player Teams New Integration", () => {
       });
 
       expect(result.error).toBe(
-        "Failed to add hero invalid-hero: Hero not found"
+        "Failed to add hero invalid-hero: Hero not found",
       );
       expect(mockTeamRepo.deleteTeam).toHaveBeenCalledWith(
         "new-team-id",
-        "user1"
+        "user1",
       );
     });
   });
@@ -433,7 +435,7 @@ describe("Player Teams New Integration", () => {
         {
           method: "POST",
           body: formData,
-        }
+        },
       );
 
       const result = await action({


### PR DESCRIPTION
Closes #114

## Summary

Adds a "static mode" that allows the app to run without a Supabase instance by serving game data from existing JSON files in `app/data/`. When Supabase environment variables are absent, the app runs as a read-only site — auth is disabled, protected routes show a "read-only mode" message, and navigation hides auth-dependent items.

## What Changed

- **Mode detection**: `app/lib/static-mode.ts` — single `isStaticMode()` function checking env vars
- **Static data providers**: `app/repositories/static/` — StaticHeroProvider, StaticEquipmentProvider, StaticMissionProvider serving from JSON files
- **Repository factory**: `app/repositories/factory.ts` — factory functions returning static or live repositories
- **Auth layer**: AuthContext, auth utils, and Supabase client all short-circuit in static mode
- **Navigation**: Player Tools hidden, user menu hidden in static mode
- **Route loaders**: 9 route files updated to use factory pattern
- **Auth routes**: login, sign-up, forgot-password redirect to `/` in static mode
- **UnauthorizedAccess**: Shows "Read-Only Mode" card instead of "Please sign in"

## Testing

- [x] TypeScript strict mode passing
- [x] 974 tests passing (66 pre-existing failures unchanged)
- [x] 39 new tests for static mode detection, providers, factory, auth utils
- [x] Updated existing tests for AuthContext, UnauthorizedAccess, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)